### PR TITLE
Expand buttons

### DIFF
--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/adapters/PermissionListAdapter.java
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/adapters/PermissionListAdapter.java
@@ -1,7 +1,6 @@
 package org.eu.exodus_privacy.exodusprivacy.adapters;
 
 import android.databinding.DataBindingUtil;
-import android.databinding.ViewDataBinding;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -10,12 +9,9 @@ import android.view.ViewGroup;
 
 import org.eu.exodus_privacy.exodusprivacy.R;
 import org.eu.exodus_privacy.exodusprivacy.databinding.PermissionItemBinding;
-import org.eu.exodus_privacy.exodusprivacy.databinding.TrackerItemBinding;
 import org.eu.exodus_privacy.exodusprivacy.objects.Permission;
-import org.eu.exodus_privacy.exodusprivacy.objects.Tracker;
 
 import java.util.List;
-import java.util.Set;
 
 public class PermissionListAdapter extends RecyclerView.Adapter<PermissionListAdapter.TrackerListViewHolder>{
 
@@ -67,10 +63,12 @@ public class PermissionListAdapter extends RecyclerView.Adapter<PermissionListAd
                 permissionItemBinding.permissionName.setText(permission.name);
                 permissionItemBinding.permissionDescription.setText(permission.description);
                 manageExpanded(permission);
-                permissionItemBinding.mainLayout.setOnClickListener((View.OnClickListener) v -> {
-                    permission.expanded = !permission.expanded;
-                    manageExpanded(permission);
-                });
+                if( permission.description != null && permission.description.trim().length() > 0)
+                    permissionItemBinding.mainLayout.setOnClickListener((View.OnClickListener) v -> {
+                        permission.expanded = !permission.expanded;
+                        manageExpanded(permission);
+                    });
+
             }
             else
                 permissionItemBinding.permissionName.setText(R.string.no_permissions);
@@ -79,13 +77,15 @@ public class PermissionListAdapter extends RecyclerView.Adapter<PermissionListAd
 
         void manageExpanded(Permission permission) {
             if(permission.expanded) {
-                permissionItemBinding.rightArrow.setVisibility(View.GONE);
-                permissionItemBinding.downArrow.setVisibility(View.VISIBLE);
+                permissionItemBinding.arrow.setText("▼");
                 permissionItemBinding.permissionDescription.setVisibility(View.VISIBLE);
             } else {
-                permissionItemBinding.rightArrow.setVisibility(View.VISIBLE);
-                permissionItemBinding.downArrow.setVisibility(View.GONE);
+                if( permission.description != null && permission.description.trim().length() > 0 )
+                    permissionItemBinding.arrow.setText("▶");
+                else
+                    permissionItemBinding.arrow.setText("■");
                 permissionItemBinding.permissionDescription.setVisibility(View.GONE);
+
             }
         }
     }

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/adapters/PermissionListAdapter.java
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/adapters/PermissionListAdapter.java
@@ -63,15 +63,18 @@ public class PermissionListAdapter extends RecyclerView.Adapter<PermissionListAd
                 permissionItemBinding.permissionName.setText(permission.name);
                 permissionItemBinding.permissionDescription.setText(permission.description);
                 manageExpanded(permission);
-                if( permission.description != null && permission.description.trim().length() > 0)
-                    permissionItemBinding.mainLayout.setOnClickListener((View.OnClickListener) v -> {
+                permissionItemBinding.mainLayout.setOnClickListener((View.OnClickListener) v -> {
+                    if( permission.description != null && permission.description.trim().length() > 0) {
                         permission.expanded = !permission.expanded;
                         manageExpanded(permission);
-                    });
+                    }
+                });
 
             }
-            else
+            else {
                 permissionItemBinding.permissionName.setText(R.string.no_permissions);
+                permissionItemBinding.arrow.setText(" ");
+            }
 
         }
 

--- a/app/src/main/res/layout/permission_item.xml
+++ b/app/src/main/res/layout/permission_item.xml
@@ -26,7 +26,6 @@
                 android:layout_marginLeft="5dp"
                 />
             <TextView
-                android:drawablePadding="10dp"
                 android:id="@+id/permission_name"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"/>

--- a/app/src/main/res/layout/permission_item.xml
+++ b/app/src/main/res/layout/permission_item.xml
@@ -15,30 +15,18 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
             <TextView
-                android:text="▶"
-                android:id="@+id/right_arrow"
-                android:textColor="@android:color/black"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="10dp"
-                android:layout_marginRight="10dp"
-
-                android:layout_marginStart="5dp"
-                android:layout_marginLeft="5dp"
-                />
-            <TextView
                 android:text="▼"
-                android:id="@+id/down_arrow"
+                android:id="@+id/arrow"
                 android:textColor="@android:color/black"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="10dp"
                 android:layout_marginRight="10dp"
-
                 android:layout_marginStart="5dp"
                 android:layout_marginLeft="5dp"
                 />
             <TextView
+                android:drawablePadding="10dp"
                 android:id="@+id/permission_name"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"/>


### PR DESCRIPTION
Some permissions have no descriptions. So, instead of putting a "▶" char that opens a blank content, the click is no longer handled and the char is replaced by "■" to show there is no content.