### PR TITLE
[WIP] Better message when version doesn't match

### DIFF
--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/adapters/ApplicationListAdapter.java
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/adapters/ApplicationListAdapter.java
@@ -219,7 +219,7 @@ public class ApplicationListAdapter extends RecyclerView.Adapter {
                     appItemBinding.appTrackerNb.setBackgroundResource(R.drawable.square_red);
 
                 if(versionName != null && !report.version.equals(data.versionName)) {
-                    String string = context.getString(R.string.tested,versionCode,report.versionCode);
+                    String string = context.getString(R.string.tested,versionName,report.version);
                     appItemBinding.otherVersion.setText(string);
                     appItemBinding.otherVersion.setVisibility(View.VISIBLE);
                 } else if (versionName == null && report.versionCode != versionCode) {

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/adapters/ApplicationListAdapter.java
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/adapters/ApplicationListAdapter.java
@@ -219,8 +219,12 @@ public class ApplicationListAdapter extends RecyclerView.Adapter {
                     appItemBinding.appTrackerNb.setBackgroundResource(R.drawable.square_red);
 
                 if(versionName != null && !report.version.equals(data.versionName)) {
+                    String string = context.getString(R.string.tested,versionCode,report.versionCode);
+                    appItemBinding.otherVersion.setText(string);
                     appItemBinding.otherVersion.setVisibility(View.VISIBLE);
                 } else if (versionName == null && report.versionCode != versionCode) {
+                    String string = context.getString(R.string.tested,String.valueOf(versionCode),String.valueOf(report.versionCode));
+                    appItemBinding.otherVersion.setText(string);
                     appItemBinding.otherVersion.setVisibility(View.VISIBLE);
                 }
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -12,7 +12,7 @@
     <string name="report_version">النسخة المُجرَّبة:</string>
     <string name="no_trackers">لم نعثر على أي متعقِّب قمنا بتجريبه</string>
     <string name="no_permissions">هذا التطبيق لا يتطلب أية تصريحات</string>
-    <string name="tested">ليس هناك أي تقرير عن النسخة المثبة، إنّ البيانات المعروضة تتعلق بنسخة قديمة لنفس التطبيق.</string>
+    <string name="tested">%1$s%2$sليس هناك أي تقرير عن النسخة المثبة، إنّ البيانات المعروضة تتعلق بنسخة قديمة لنفس التطبيق.</string>
     <string name="analysed">لم يتم بعد فحص هذا التطبيق بواسطة Exodus Privacy</string>
     <string name="no_package_manager">يبدو أنّ نظام جهازك لا يسمح بالوصول إلى قائمة التطبيقات المثبة.</string>
     <string name="no_app_found">يبدو أنّك لم تقم بتثبيت أي تطبيق مِن المصدر الذي نقوم بفحصه (متجر جوجل للتطبيقات).</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -12,7 +12,7 @@
     <string name="report_version">Getestete Version: </string>
     <string name="no_trackers">Es wurden keine Tracker gefunden</string>
     <string name="no_permissions">Diese App braucht keine Berechtigungen</string>
-    <string name="tested">Es gibt keinen Bericht für die installierte Version, die gezeigte Informationen basieren auf eine andere (wahrscheinlich ältere) Version</string>
+    <string name="tested">Es gibt keinen Bericht für die installierte Version (%1$s), die gezeigte Informationen basieren auf eine andere (%2$s) Version</string>
     <string name="analysed">Diese App wurde von Exodus noch nicht analysiert</string>
     <string name="no_package_manager">Ihr System scheint den Zugriff auf die Appliste nicht zu erlauben.</string>
     <string name="no_app_found">Es scheint, dass keine App aus der Quelle, die wir prüfen (Google Play Store), installiert ist.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -12,7 +12,7 @@
     <string name="report_version">Versión verificada: </string>
     <string name="no_trackers">Ningún rastreador verificado ha sido encontrado</string>
     <string name="no_permissions">Esta applicación no requiere autorizaciones</string>
-    <string name="tested">No existe informe para la versión instalada, las informaciones mostradas se basan en otra versión (seguramente más antigua)</string>
+    <string name="tested">No existe informe para la versión instalada (%1$s), las informaciones mostradas se basan en otra versión (%2$s)</string>
     <string name="analysed">Esta applicación aún no ha sido analizada por Exodus Privacy.</string>
     <string name="no_package_manager">Parece que tu sistema no autoriza el acceso a la lista de aplicaciones instaladas.</string>
     <string name="no_app_found">Parece que no tienes ninguna aplicación de la plataforma que analizamos (Google Play).</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -12,7 +12,7 @@
     <string name="report_version">Version testée : </string>
     <string name="no_trackers">Aucun pisteur testé n\'a été trouvé</string>
     <string name="no_permissions">Aucune autorisation n\'est demandée par cette application</string>
-    <string name="tested">Il n\'y a pas de rapport pour la version installée, les informations affichées sont basées sur une autre version (vraisemblablement plus ancienne)</string>
+    <string name="tested">Il n\'y a pas de rapport pour la version installée (%1$s), les informations affichées sont basées sur une autre version (%2$s)</string>
     <string name="analysed">Cette application n\'a pas encore été analysée par Exodus Privacy.</string>
     <string name="no_package_manager">Votre système semble ne pas donner accès aux applications installées.</string>
     <string name="no_app_found">Vous semblez n\'avoir aucune application installée par la source que nous recherchons (Google Play).</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -12,7 +12,7 @@
     <string name="report_version">Versione testata: </string>
     <string name="no_trackers">Nessun tracciatore testato trovato</string>
     <string name="no_permissions">Nessuna autorizzazione richiesta dall\'applicazione</string>
-    <string name="tested">Non ci sono report per la versione installata, le informazioni mostrate sono basate su un\'altra (presumibilmente più vecchia) versione</string>
+    <string name="tested">Non ci sono report per la versione installata (%1$s), le informazioni mostrate sono basate su un\'altra (%2$s) versione</string>
     <string name="analysed">Questa app non è ancora stata analizzata da Exodus Privacy.</string>
     <string name="no_package_manager">Sembra che il tuo sistema non permetta l\'accesso all\'elenco di app installate.</string>
     <string name="no_app_found">Sembra che tu non abbia alcuna app installa dalla fonte che testiamo (Google Play store).</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
     <string name="report_version">Tested Version: </string>
     <string name="no_trackers">No tested trackers were found</string>
     <string name="no_permissions">No permissions are requested by this application</string>
-    <string name="tested">There\'s no report for the installed version, the information displayed is based on another (presumably older) version</string>
+    <string name="tested">There\'s no report for the installed version (%1$s), the information displayed is based on another (%2$s) version</string>
     <string name="analysed">This app hasn\'t been analysed by Exodus Privacy yet.</string>
     <string name="no_package_manager">It appears that your system doesn\'t allow access to the list of installed apps.</string>
     <string name="no_app_found">It appears that you don\'t have any apps installed from the source we test (Google Play store).</string>


### PR DESCRIPTION
A proposition to improve the message.

Instead of:

> There\'s no report for the installed version, the information displayed is based on another (presumably older) version

it says (for example):

> There's no report for the installed version (1.2.0), the information displayed is based on another (1.0.0) version

When the version code is not available, it uses the version number.

DO NOT MERGE YET: The Arabic translation **IS NOT correct** (if someone could help with that...)