### PR TITLE
fix: add margins in application cell

### DIFF
--- a/app/src/main/res/layout/app_item.xml
+++ b/app/src/main/res/layout/app_item.xml
@@ -10,6 +10,8 @@
 
         <RelativeLayout
             android:id="@+id/base_info"
+            android:layout_marginTop="10dp"
+            android:layout_marginBottom="5dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
             <ImageView


### PR DESCRIPTION
Hi,

Here is a microscopic PR to fix a margin issue. Application icons were colliding with the cells separators :)

<img width="201" alt="Capture d’écran 2019-05-16 à 20 37 00" src="https://user-images.githubusercontent.com/22218860/57878848-4646b580-781b-11e9-8f24-34b007f3d178.png">
