### PR TITLE
feat(applications): improve recyclerview scrolling

### DIFF
--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/adapters/ApplicationListAdapter.java
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/adapters/ApplicationListAdapter.java
@@ -167,7 +167,7 @@ public class ApplicationListAdapter extends RecyclerView.Adapter {
                 @Override
                 public void onClick(View v) {
                     try {
-                        PackageInfo packageInfo = packageManager.getPackageInfo(holder.viewModel.packageName, 0);
+                        PackageInfo packageInfo = packageManager.getPackageInfo(holder.viewModel.packageName, PackageManager.GET_PERMISSIONS);
                         onAppClickListener.onAppClick(packageInfo);
                     } catch (PackageManager.NameNotFoundException e) {
                         e.printStackTrace();


### PR DESCRIPTION
I noticed that scrolling in the application list wasn't smooth so I worked on some improvements.

- multiple access to the database is done each time a cell is rendered in the `onBindViewHolder()` method. I fixed that by extracting all the values needed to be displayed into a `ViewModel` class
- computation to check whether or not a cell is visible is done in the `getItemViewType()` method. I fixed that by computing the visibility right after a search.

Working with a ViewModel class allows features such as #45 and #22 to be implemented easily.

Cheers
🌮 

