### PR TITLE
app_item.xml: Use icons instead of text

### DIFF
--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/adapters/ApplicationListAdapter.java
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/adapters/ApplicationListAdapter.java
@@ -125,8 +125,8 @@ public class ApplicationListAdapter extends RecyclerView.Adapter {
             Context context = appItemBinding.getRoot().getContext();
 
             //reinit view state
-            appItemBinding.otherVersion.setVisibility(View.GONE);
-            appItemBinding.analysed.setVisibility(View.GONE);
+            appItemBinding.appOutdated.setVisibility(View.GONE);
+            appItemBinding.appUnknown.setVisibility(View.GONE);
             appItemBinding.appTrackerNb.setVisibility(View.VISIBLE);
             appItemBinding.appTracker.setVisibility(View.VISIBLE);
 
@@ -160,18 +160,14 @@ public class ApplicationListAdapter extends RecyclerView.Adapter {
                     appItemBinding.appTrackerNb.setBackgroundResource(R.drawable.square_red);
 
                 if(versionName != null && !report.version.equals(viewModel.versionName)) {
-                    String string = context.getString(R.string.tested,versionName, report.version);
-                    appItemBinding.otherVersion.setText(string);
-                    appItemBinding.otherVersion.setVisibility(View.VISIBLE);
+                    appItemBinding.appOutdated.setVisibility(View.VISIBLE);
                 } else if (versionName == null && report.versionCode != versionCode) {
-                    String string = context.getString(R.string.tested,String.valueOf(versionCode),String.valueOf(report.versionCode));
-                    appItemBinding.otherVersion.setText(string);
-                    appItemBinding.otherVersion.setVisibility(View.VISIBLE);
+                    appItemBinding.appOutdated.setVisibility(View.VISIBLE);
                 }
             } else {
                 appItemBinding.appTrackerNb.setVisibility(View.GONE);
                 appItemBinding.appTracker.setVisibility(View.GONE);
-                appItemBinding.analysed.setVisibility(View.VISIBLE);
+                appItemBinding.appUnknown.setVisibility(View.VISIBLE);
             }
         }
     }

--- a/app/src/main/res/drawable/ic_report_problem.xml
+++ b/app/src/main/res/drawable/ic_report_problem.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M1,21h22L12,2 1,21zM13,18h-2v-2h2v2zM13,14h-2v-4h2v4z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_update.xml
+++ b/app/src/main/res/drawable/ic_update.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M21,10.12h-6.78l2.74,-2.82c-2.73,-2.7 -7.15,-2.8 -9.88,-0.1 -2.73,2.71 -2.73,7.08 0,9.79 2.73,2.71 7.15,2.71 9.88,0C18.32,15.65 19,14.08 19,12.1h2c0,1.98 -0.88,4.55 -2.64,6.29 -3.51,3.48 -9.21,3.48 -12.72,0 -3.5,-3.47 -3.53,-9.11 -0.02,-12.58 3.51,-3.47 9.14,-3.47 12.65,0L21,3v7.12zM12.5,8v4.25l3.5,2.08 -0.72,1.21L11,13V8h1.5z"/>
+</vector>

--- a/app/src/main/res/layout/app_item.xml
+++ b/app/src/main/res/layout/app_item.xml
@@ -32,7 +32,6 @@
                 android:layout_centerInParent="true"
                 android:orientation="horizontal">
 
-
                 <ImageView
                     android:id="@+id/app_outdated"
                     android:layout_width="30dp"
@@ -47,29 +46,56 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:orientation="vertical">
+
                     <LinearLayout
                         android:orientation="horizontal"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content">
 
-
-                    <TextView
-                        android:id="@+id/app_tracker_nb"
-                        android:layout_width="30dp"
-                        android:layout_height="@dimen/app_item_square_height"
-                        android:background="@drawable/square_green"
-                        android:textAlignment="center"
-                        android:background="@drawable/square_green"
-                        android:id="@+id/app_permission_nb"
-                        android:layout_width="30dp"
-                        android:layout_height="wrap_content" />
-                    <TextView
-                        android:layout_marginLeft="5dp"
-                        android:layout_marginStart="5dp"
-                        android:text="@string/permissions"
-                        android:id="@+id/app_permission"
+                        <TextView
+                            android:id="@+id/app_tracker_nb"
+                            android:layout_width="30dp"
+                            android:layout_height="@dimen/app_item_square_height"
+                            android:background="@drawable/square_green"
+                            android:textAlignment="center" />
+                        <TextView
+                            android:layout_marginLeft="5dp"
+                            android:layout_marginStart="5dp"
+                            android:text="@string/trackers"
+                            android:id="@+id/app_tracker"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content" />
+                    </LinearLayout>
+                    <LinearLayout
+                        android:orientation="horizontal"
                         android:layout_width="wrap_content"
-                        android:layout_height="wrap_content" />
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="5dp">
+
+                        <ImageView
+                            android:id="@+id/app_unknown"
+                            android:layout_width="30dp"
+                            android:padding="3dp"
+                            android:layout_height="@dimen/app_item_square_height"
+                            android:background="@drawable/square_red"
+                            app:srcCompat="@drawable/ic_report_problem"
+                            android:layout_marginRight="5dp"
+                            android:layout_marginEnd="5dp" />
+
+                        <TextView
+                            android:id="@+id/app_permission_nb"
+                            android:layout_width="30dp"
+                            android:layout_height="@dimen/app_item_square_height"
+                            android:background="@drawable/square_green"
+                            android:textAlignment="center" />
+                        <TextView
+                            android:layout_marginLeft="5dp"
+                            android:layout_marginStart="5dp"
+                            android:text="@string/permissions"
+                            android:id="@+id/app_permission"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content" />
+                    </LinearLayout>
                 </LinearLayout>
             </LinearLayout>
             <TextView

--- a/app/src/main/res/layout/app_item.xml
+++ b/app/src/main/res/layout/app_item.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout
+<layout xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
     >
     <data/>
@@ -25,37 +25,39 @@
                 android:layout_marginEnd="5dp"/>
             <LinearLayout
                 android:id="@+id/layout_infos"
-                android:orientation="vertical"
-                android:layout_centerInParent="true"
-                android:layout_alignParentRight="true"
-                android:layout_alignParentEnd="true"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content">
+                android:layout_height="wrap_content"
+                android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
+                android:layout_centerInParent="true"
+                android:orientation="horizontal">
+
+
+                <ImageView
+                    android:id="@+id/app_outdated"
+                    android:layout_width="30dp"
+                    android:padding="3dp"
+                    android:layout_height="@dimen/app_item_square_height"
+                    android:background="@drawable/square_red"
+                    app:srcCompat="@drawable/ic_update"
+                    android:layout_marginRight="5dp"
+                    android:layout_marginEnd="5dp" />
+
                 <LinearLayout
-                    android:orientation="horizontal"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content">
-                    <TextView
-                        android:textAlignment="center"
-                        android:background="@drawable/square_green"
-                        android:id="@+id/app_tracker_nb"
-                        android:layout_width="30dp"
-                        android:layout_height="wrap_content" />
-                    <TextView
-                        android:layout_marginLeft="5dp"
-                        android:layout_marginStart="5dp"
-                        android:text="@string/trackers"
-                        android:id="@+id/app_tracker"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content" />
-                </LinearLayout>
-                <LinearLayout
-                    android:orientation="horizontal"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="5dp"
-                    >
+                    android:orientation="vertical">
+                    <LinearLayout
+                        android:orientation="horizontal"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content">
+
+
                     <TextView
+                        android:id="@+id/app_tracker_nb"
+                        android:layout_width="30dp"
+                        android:layout_height="@dimen/app_item_square_height"
+                        android:background="@drawable/square_green"
                         android:textAlignment="center"
                         android:background="@drawable/square_green"
                         android:id="@+id/app_permission_nb"
@@ -81,25 +83,5 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
         </RelativeLayout>
-        <TextView
-            android:layout_below="@+id/base_info"
-            android:id="@+id/other_version"
-            android:text="@string/tested"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-        <TextView
-            android:layout_below="@+id/other_version"
-            android:id="@+id/analysed"
-            android:text="@string/analysed"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-        <TextView
-            android:layout_below="@+id/analysed"
-            android:layout_alignParentBottom="true"
-            style="?android:attr/listSeparatorTextViewStyle"
-            android:layout_width="match_parent"
-            android:layout_height="10dp" />
-
-
     </RelativeLayout>
 </layout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="app_item_square_height">21dp</dimen>
+</resources>


### PR DESCRIPTION
The text for not analyzed and outdated apps is very annoying and takes up a lot of space. So I changed the code to use two icons with red background instead of the text, next to the two numbers in the app list. Since clicking on a app explains that the app either wasn't analyzed or outdated, should make it clear, what both icons mean. Without the text, the app list looks a lot better and organized. 