### PR TITLE
Introduce About Fragment

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,6 +94,7 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,17 +17,12 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            lintOptions {
+            lint {
                 disable 'MissingTranslation'
             }
         }
     }
 
-    lintOptions {
-        disable 'MissingTranslation'
-        checkReleaseBuilds false
-        abortOnError false
-    }
 
     productFlavors {
         exodus_google {
@@ -89,6 +84,11 @@ android {
     }
     buildFeatures {
         dataBinding = true
+    }
+    lint {
+        abortOnError false
+        checkReleaseBuilds false
+        disable 'MissingTranslation'
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,10 +97,10 @@ dependencies {
     androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    implementation 'androidx.appcompat:appcompat:1.4.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'com.google.android.material:material:1.5.0'
     testImplementation 'junit:junit:4.13.2'
 }

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/MainActivity.java
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/MainActivity.java
@@ -51,6 +51,7 @@ import org.eu.exodus_privacy.exodusprivacy.adapters.ApplicationListAdapter;
 import org.eu.exodus_privacy.exodusprivacy.adapters.ApplicationViewModel;
 import org.eu.exodus_privacy.exodusprivacy.adapters.TrackerListAdapter;
 import org.eu.exodus_privacy.exodusprivacy.databinding.MainBinding;
+import org.eu.exodus_privacy.exodusprivacy.fragments.AboutFragment;
 import org.eu.exodus_privacy.exodusprivacy.fragments.ComputeAppList;
 import org.eu.exodus_privacy.exodusprivacy.fragments.HomeFragment;
 import org.eu.exodus_privacy.exodusprivacy.fragments.MyTrackersFragment;
@@ -79,6 +80,8 @@ public class MainActivity extends AppCompatActivity {
             binding.viewpager.setCurrentItem(0);
         } else if (itemId == R.id.navigation_analytics) {
             binding.viewpager.setCurrentItem(1);
+        } else if (itemId == R.id.aboutExodus) {
+            binding.viewpager.setCurrentItem(2);
         }
         return true;
     };
@@ -351,6 +354,8 @@ public class MainActivity extends AppCompatActivity {
                     MyTrackersFragment myTrackersFragment = new MyTrackersFragment();
                     myTrackersFragment.setOnTrackerClickListener(onTrackerClickListener);
                     return myTrackersFragment;
+                case 2:
+                    return new AboutFragment();
                 default:
                     return home;
             }
@@ -358,7 +363,7 @@ public class MainActivity extends AppCompatActivity {
 
         @Override
         public int getCount() {
-            return 2;
+            return 3;
         }
     }
 

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/AboutFragment.java
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/AboutFragment.java
@@ -7,6 +7,7 @@ import android.text.method.LinkMovementMethod;
 import android.text.style.URLSpan;
 import android.text.style.UnderlineSpan;
 import android.view.LayoutInflater;
+import android.view.Menu;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -34,6 +35,7 @@ public class AboutFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+        setHasOptionsMenu(true);
         Spannable privacyPolicy = (Spannable) HtmlCompat.fromHtml(
                 getString(R.string.privacyPolicy, privacyPolicyURL),
                 HtmlCompat.FROM_HTML_MODE_COMPACT
@@ -47,6 +49,13 @@ public class AboutFragment extends Fragment {
         }
         binding.privacyTV.setText(privacyPolicy);
         binding.privacyTV.setMovementMethod(LinkMovementMethod.getInstance());
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(@NonNull Menu menu) {
+        menu.findItem(R.id.action_filter).setVisible(false);
+        menu.findItem(R.id.action_settings).setVisible(false);
+        menu.findItem(R.id.action_filter_options).setVisible(false);
     }
 
     @Override

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/AboutFragment.java
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/AboutFragment.java
@@ -1,12 +1,18 @@
 package org.eu.exodus_privacy.exodusprivacy.fragments;
 
 import android.os.Bundle;
+import android.text.Spannable;
+import android.text.TextPaint;
+import android.text.method.LinkMovementMethod;
+import android.text.style.URLSpan;
+import android.text.style.UnderlineSpan;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.text.HtmlCompat;
 import androidx.databinding.DataBindingUtil;
 import androidx.fragment.app.Fragment;
 
@@ -16,6 +22,7 @@ import org.eu.exodus_privacy.exodusprivacy.databinding.FragmentAboutBinding;
 public class AboutFragment extends Fragment {
 
     private FragmentAboutBinding binding;
+    private final String privacyPolicyURL = "https://exodus-privacy.eu.org/en/page/privacy-policy/";
 
     @Nullable
     @Override
@@ -27,6 +34,19 @@ public class AboutFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+        Spannable privacyPolicy = (Spannable) HtmlCompat.fromHtml(
+                getString(R.string.privacyPolicy, privacyPolicyURL),
+                HtmlCompat.FROM_HTML_MODE_COMPACT
+        );
+        for (URLSpan urlSpan : privacyPolicy.getSpans(0, privacyPolicy.length(), URLSpan.class)) {
+            privacyPolicy.setSpan(new UnderlineSpan() {
+                public void updateDrawState(TextPaint textPaint) {
+                    textPaint.setUnderlineText(false);
+                }
+            }, privacyPolicy.getSpanStart(urlSpan), privacyPolicy.getSpanEnd(urlSpan), 0);
+        }
+        binding.privacyTV.setText(privacyPolicy);
+        binding.privacyTV.setMovementMethod(LinkMovementMethod.getInstance());
     }
 
     @Override

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/AboutFragment.java
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/AboutFragment.java
@@ -1,0 +1,37 @@
+package org.eu.exodus_privacy.exodusprivacy.fragments;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.databinding.DataBindingUtil;
+import androidx.fragment.app.Fragment;
+
+import org.eu.exodus_privacy.exodusprivacy.R;
+import org.eu.exodus_privacy.exodusprivacy.databinding.FragmentAboutBinding;
+
+public class AboutFragment extends Fragment {
+
+    private FragmentAboutBinding binding;
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_about, container, false);
+        return binding.getRoot();
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
+}

--- a/app/src/main/res/drawable/ic_information.xml
+++ b/app/src/main/res/drawable/ic_information.xml
@@ -1,0 +1,13 @@
+<!-- drawable/information_outline.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?android:attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    tools:ignore="VectorRaster">
+    <path
+        android:fillColor="#000"
+        android:pathData="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z" />
+</vector>

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -26,11 +26,22 @@
             android:textStyle="bold" />
 
         <TextView
-            android:padding="10dp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
+            android:padding="10dp"
             android:text="@string/aboutExodusDesc"
+            android:textAlignment="center"
+            android:textColor="?android:textColorPrimary"
+            android:textSize="16sp" />
+
+        <TextView
+            android:id="@+id/privacyTV"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:padding="10dp"
+            android:text="@string/privacyPolicy"
             android:textAlignment="center"
             android:textColor="?android:textColorPrimary"
             android:textSize="16sp" />

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".fragments.AboutFragment">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="15dp"
+        android:gravity="center"
+        android:orientation="vertical">
+
+        <ImageView
+            android:id="@+id/imageView"
+            android:layout_width="96dp"
+            android:layout_height="96dp"
+            android:src="@drawable/ic_logo" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:text="@string/aboutExodusTitle"
+            android:textColor="?android:textColorPrimary"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:padding="10dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:text="@string/aboutExodusDesc"
+            android:textAlignment="center"
+            android:textColor="?android:textColorPrimary"
+            android:textSize="16sp" />
+    </LinearLayout>
+</layout>

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -10,5 +10,10 @@
         android:id="@+id/navigation_analytics"
         android:icon="@drawable/ic_baseline_analytics_24"
         android:title="@string/title_trackers" />
+
+    <item
+        android:id="@+id/aboutExodus"
+        android:icon="@drawable/ic_information"
+        android:title="@string/title_about" />
     
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,9 +64,14 @@
     <string name="app_not_analyzed_title">This app has not been analyzed!</string>
     <string name="title_apps">My apps</string>
     <string name="title_trackers">Trackers</string>
+    <string name="title_about">About</string>
     <string name="list_of_apps">See the list of apps</string>
     <string name="apps">%1$s apps</string>
     <string name="nothing_here">Nothing to display currently. You can pull to refresh!</string>
+
+    <!-- About Fragment -->
+    <string name="aboutExodusTitle">About Exodus - Android Application</string>
+    <string name="aboutExodusDesc">Exodus is an Android application that let you know what trackers are embedded in apps installed on your smartphone using the exodus platform. It let you also know the permissions required by any apps on your smartphone.\n\nIt helps you to take your privacy back!</string>
 
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,7 +72,7 @@
     <!-- About Fragment -->
     <string name="aboutExodusTitle">About Exodus - Android Application</string>
     <string name="aboutExodusDesc">Exodus is an Android application that let you know what trackers are embedded in apps installed on your smartphone using the exodus platform. It let you also know the permissions required by any apps on your smartphone.\n\nIt helps you to take your privacy back!</string>
-    <string name="privacyPolicy">&#8226; Checkout our privacy policy &lt;a href="<xliff:g id="exodus">%1$s</xliff:g>"&gt;here&lt;/a&gt;</string>
+    <string name="privacyPolicy">&#8226; &lt;a href="<xliff:g id="exodus">%1$s</xliff:g>"&gt;Checkout our privacy policy here ➤&lt;/a&gt;</string>
 
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="app_logo">Application Logo</string>
     <string name="trackers_pct">Trackers:</string>
     <string name="permissions_pct">Permissions:</string>
@@ -72,6 +72,7 @@
     <!-- About Fragment -->
     <string name="aboutExodusTitle">About Exodus - Android Application</string>
     <string name="aboutExodusDesc">Exodus is an Android application that let you know what trackers are embedded in apps installed on your smartphone using the exodus platform. It let you also know the permissions required by any apps on your smartphone.\n\nIt helps you to take your privacy back!</string>
+    <string name="privacyPolicy">&#8226; Checkout our privacy policy &lt;a href="<xliff:g id="exodus">%1$s</xliff:g>"&gt;here&lt;/a&gt;</string>
 
 
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath 'com.android.tools.build:gradle:7.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip


### PR DESCRIPTION
This MR:

- Upstreams the Gradle and dependencies to the latest stable release
- Adds a new About Fragment which displays app logo, description, and privacy policy URL (not hosted on the server yet)

This should close https://github.com/Exodus-Privacy/exodus-android-app/issues/111, however, keep in mind that the URL seems not hosted or public yet and should be handled as well.

The URL can be changed by maintainers by editing the variable value in `app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/AboutFragment.java`