### PR TITLE
ci: Scan with exodus-standalone 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,9 +24,8 @@ jobs:
       - name: Run tests
         run: ./gradlew test
       - name: Execute exodus-standalone
-        uses: docker://exodusprivacy/exodus-standalone:v1.3.0
+        uses: docker://exodusprivacy/exodus-standalone:v1.3.1
         with:
-          entrypoint: /exodus_analyze.py
           args: /github/workspace/app/build/outputs/apk/debug/app-debug.apk
       - name: Upload APK
         uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,11 @@ jobs:
         run: ./gradlew assembleDebug
       - name: Run tests
         run: ./gradlew test
+      - name: Execute exodus-standalone
+        uses: docker://exodusprivacy/exodus-standalone:v1.3.0
+        with:
+          entrypoint: /exodus_analyze.py
+          args: /github/workspace/app/build/outputs/apk/debug/app-debug.apk
       - name: Upload APK
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
### Content

Fixes #134 

Adds a new step to GitHub Actions to scan the generated apk with [exodus-standalone](https://github.com/Exodus-Privacy/exodus-standalone)

### Todo

- [x] Update exodus-standalone README with this example -> https://github.com/Exodus-Privacy/exodus-standalone/pull/39