### PR TITLE
Fix name file for latest changelogs

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/10.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10.txt
@@ -1,5 +1,0 @@
-- Add tabs on application
-- Add function to filter reports
-- Add link to privacy policy
-- Add function to show reports or submit application with link from Android share menu
-- Fix bugs

--- a/fastlane/metadata/android/en-US/changelogs/11.txt
+++ b/fastlane/metadata/android/en-US/changelogs/11.txt
@@ -1,3 +1,5 @@
-- Add new permission QUERY_ALL_PACKAGES
-- Bump dependencies
-- Fix translations
+- Add tabs on application
+- Add function to filter reports
+- Add link to privacy policy
+- Add function to show reports or submit application with link from Android share menu
+- Fix bugs

--- a/fastlane/metadata/android/en-US/changelogs/12.txt
+++ b/fastlane/metadata/android/en-US/changelogs/12.txt
@@ -1,0 +1,3 @@
+- Add new permission QUERY_ALL_PACKAGES
+- Bump dependencies
+- Fix translations

--- a/fastlane/metadata/android/fr-FR/changelogs/10.txt
+++ b/fastlane/metadata/android/fr-FR/changelogs/10.txt
@@ -1,5 +1,0 @@
-- Ajout d'onglets sur l'application
-- Ajout d'une fonction pour trier les rapports
-- Ajout d'un lien vers la politique de confidentialité
-- Ajout d'une fonction pour visualiser un rapport ou soumettre une application à partir d'un lien via le menu partager d'Android
-- Correction de bugs

--- a/fastlane/metadata/android/fr-FR/changelogs/11.txt
+++ b/fastlane/metadata/android/fr-FR/changelogs/11.txt
@@ -1,3 +1,5 @@
-- Ajout de la permission QUERY_ALL_PACKAGES
-- Mise à jour des dépendances
-- Mise à jour des traductions
+- Ajout d'onglets sur l'application
+- Ajout d'une fonction pour trier les rapports
+- Ajout d'un lien vers la politique de confidentialité
+- Ajout d'une fonction pour visualiser un rapport ou soumettre une application à partir d'un lien via le menu partager d'Android
+- Correction de bugs

--- a/fastlane/metadata/android/fr-FR/changelogs/12.txt
+++ b/fastlane/metadata/android/fr-FR/changelogs/12.txt
@@ -1,0 +1,3 @@
+- Ajout de la permission QUERY_ALL_PACKAGES
+- Mise à jour des dépendances
+- Mise à jour des traductions


### PR DESCRIPTION
- With release 2.2.0, i have doing error in name on latest changelogs en/fr.
- Because for release 2.1.1, we have not changelog. (changelog is not necessary, this release was created to fix bugs).