### PR TITLE
fix: add no internet Snackbar and fix crash #178

### DIFF
--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/MainActivityViewModel.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/MainActivityViewModel.kt
@@ -1,14 +1,9 @@
 package org.eu.exodus_privacy.exodusprivacy
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import org.eu.exodus_privacy.exodusprivacy.manager.network.NetworkManager
 import org.eu.exodus_privacy.exodusprivacy.utils.DataStoreModule
 import javax.inject.Inject
@@ -24,27 +19,8 @@ class MainActivityViewModel @Inject constructor(
     val policyAgreement = dataStoreModule.policyAgreement.asLiveData()
     val appSetup = dataStoreModule.appSetup.asLiveData()
 
-    private var networkScope = CoroutineScope(Dispatchers.IO)
-    private val _networkConnection: MutableLiveData<Boolean> = MutableLiveData()
-    private val networkObserver: (connected: Boolean) -> Unit = {
-        viewModelScope.launch {
-            _networkConnection.value = it
-        }
-    }
-
     val networkConnection: LiveData<Boolean>
         get() {
-            val liveData = _networkConnection
-            networkScope.launch {
-                networkManager.addObserver(networkObserver)
-            }
-            return liveData
+            return networkManager.connectionObserver
         }
-
-    override fun onCleared() {
-        networkScope.launch {
-            networkManager.removeObserver(networkObserver)
-        }
-        super.onCleared()
-    }
 }

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/MainActivityViewModel.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/MainActivityViewModel.kt
@@ -1,16 +1,50 @@
 package org.eu.exodus_privacy.exodusprivacy
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.eu.exodus_privacy.exodusprivacy.manager.network.NetworkManager
 import org.eu.exodus_privacy.exodusprivacy.utils.DataStoreModule
 import javax.inject.Inject
 
 @HiltViewModel
 class MainActivityViewModel @Inject constructor(
-    dataStoreModule: DataStoreModule
+    dataStoreModule: DataStoreModule,
 ) : ViewModel() {
+
+    @Inject
+    lateinit var networkManager: NetworkManager
 
     val policyAgreement = dataStoreModule.policyAgreement.asLiveData()
     val appSetup = dataStoreModule.appSetup.asLiveData()
+
+    private var networkScope = CoroutineScope(Dispatchers.IO)
+    private val _networkConnection: MutableLiveData<Boolean> = MutableLiveData()
+    private val networkObserver: (connected: Boolean) -> Unit = {
+        viewModelScope.launch {
+            _networkConnection.value = it
+        }
+    }
+
+    val networkConnection: LiveData<Boolean>
+        get() {
+            val liveData = _networkConnection
+            networkScope.launch {
+                networkManager.addObserver(networkObserver)
+            }
+            return liveData
+        }
+
+    override fun onCleared() {
+        networkScope.launch {
+            networkManager.removeObserver(networkObserver)
+        }
+        super.onCleared()
+    }
 }

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/apps/AppsFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/apps/AppsFragment.kt
@@ -6,7 +6,6 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.PopupMenu
-import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -79,8 +78,6 @@ class AppsFragment : Fragment(R.layout.fragment_apps) {
         binding.swipeRefreshLayout.setOnRefreshListener {
             binding.swipeRefreshLayout.isRefreshing = false
             if (!ExodusUpdateService.IS_SERVICE_RUNNING) {
-                Toast.makeText(view.context, getString(R.string.fetching_apps), Toast.LENGTH_SHORT)
-                    .show()
                 val intent = Intent(view.context, ExodusUpdateService::class.java)
                 intent.apply {
                     action = ExodusUpdateService.START_SERVICE

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/trackers/TrackersFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/trackers/TrackersFragment.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
-import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -56,8 +55,6 @@ class TrackersFragment : Fragment(R.layout.fragment_trackers) {
         binding.swipeRefreshLayout.setOnRefreshListener {
             binding.swipeRefreshLayout.isRefreshing = false
             if (!ExodusUpdateService.IS_SERVICE_RUNNING) {
-                Toast.makeText(view.context, getString(R.string.fetching_apps), Toast.LENGTH_SHORT)
-                    .show()
                 val intent = Intent(view.context, ExodusUpdateService::class.java)
                 intent.apply {
                     action = ExodusUpdateService.START_SERVICE

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/network/NetworkManager.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/network/NetworkManager.kt
@@ -1,0 +1,70 @@
+package org.eu.exodus_privacy.exodusprivacy.manager.network
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import androidx.core.content.ContextCompat
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.net.URL
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class NetworkManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+
+    private var observers = mutableListOf<(connected: Boolean) -> Unit>()
+
+    init {
+        ContextCompat.getSystemService(
+            context,
+            ConnectivityManager::class.java
+        )?.registerDefaultNetworkCallback(
+            object : ConnectivityManager.NetworkCallback() {
+                override fun onAvailable(network: Network) {
+                    super.onAvailable(network)
+                    doForEachObserver(checkURL())
+                }
+
+                override fun onLost(network: Network) {
+                    super.onLost(network)
+                    doForEachObserver(false)
+                }
+            }
+        )
+    }
+
+    fun addObserver(observer: (connected: Boolean) -> Unit) {
+        this.observers.add(observer)
+    }
+
+    fun removeObserver(observer: (connected: Boolean) -> Unit) {
+        this.observers.remove(observer)
+    }
+
+    // Prevent concurrent modification exception
+    private fun doForEachObserver(connected: Boolean) {
+        val iterator = observers.iterator()
+        while (iterator.hasNext()) {
+            iterator.next().invoke(connected)
+        }
+    }
+
+    private fun checkURL(): Boolean {
+        return try {
+            URL(ExodusAPIInterface.BASE_URL)
+                .openConnection()
+                .connect()
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    fun checkConnection() {
+        observers.forEach {
+            it.invoke(checkURL())
+        }
+    }
+}

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/NotificationManagerModule.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/NotificationManagerModule.kt
@@ -41,7 +41,6 @@ object NotificationManagerModule {
         )
     }
 
-    @Singleton
     @Provides
     fun provideUpdateNotification(
         @ApplicationContext context: Context

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,14 +8,19 @@
     tools:context=".MainActivity"
     tools:theme="@style/Theme.Exodus">
 
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/fragmentContainerView"
-        android:name="androidx.navigation.fragment.NavHostFragment"
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/fragmentCoordinator"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"
-        app:defaultNavHost="true"
-        app:navGraph="@navigation/navigation_resource" />
+        android:layout_weight="1">
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/fragmentContainerView"
+            android:name="androidx.navigation.fragment.NavHostFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:defaultNavHost="true"
+            app:navGraph="@navigation/navigation_resource" />
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottomNavView"

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -6,6 +6,7 @@
     <string name="permissions">Autorisations</string>
     <string name="network_error">Réseau indisponible</string>
     <string name="not_connected">Aucune connexion Internet</string>
+    <string name="settings">Paramètres</string>
     <string name="json_error">Erreur JSON</string>
     <string name="no_trackers">L\'application pourrait contenir un ou plusieurs pisteurs que nous n\'avons pas encore identifiés.</string>
 	<string name="version_equals">Version installée = Version analysée</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="permissions">Permissions</string>
     <string name="network_error">Network Unavailable</string>
     <string name="not_connected">No Internet Connection</string>
+    <string name="settings">Settings</string>
     <string name="json_error">JSON Error</string>
     <string name="no_trackers">The application could contain tracker(s) we do not know yet.</string>
     <string name="version_equals">Installed Version = Analyzed Version</string>


### PR DESCRIPTION
 - The network connection is made by observers that are attached to the viewModel of the activity and directly in the service.
 - The coroutines are changed to cancel the job when necessary and when the service is closed.
 - I also moved the Toast for the data fetch to put it in the service. The code is called only once and is only run if the service performs the action.

I tried to adapt to the style by using Dagger but I used an anonymous function for the observers. Let me know if it's ok for you.