### PR TITLE
Show all permissions on ADPermissionsFragment

### DIFF
--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/model/ADPermissionsRVAdapter.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/model/ADPermissionsRVAdapter.kt
@@ -32,14 +32,19 @@ class ADPermissionsRVAdapter :
         holder.binding.apply {
             permissionTitleTV.text = app.permission
             permissionSubTitleTV.text = app.label.replaceFirstChar { it.uppercase() }
-            expandBT.setOnClickListener {
-                if (permissionDescTV.isVisible) {
-                    expandBT.setIconResource(R.drawable.ic_down)
-                    permissionDescTV.visibility = View.GONE
-                } else {
-                    expandBT.setIconResource(R.drawable.ic_up)
-                    permissionDescTV.text = app.description
-                    permissionDescTV.visibility = View.VISIBLE
+            if (app.description == "Null" || app.description == "null" || app.description == "") {
+                permissionDescTV.visibility = View.GONE
+                expandBT.visibility = View.GONE
+            } else {
+                expandBT.setOnClickListener {
+                    if (permissionDescTV.isVisible) {
+                        expandBT.setIconResource(R.drawable.ic_down)
+                        permissionDescTV.visibility = View.GONE
+                    } else {
+                        expandBT.setIconResource(R.drawable.ic_up)
+                        permissionDescTV.text = app.description
+                        permissionDescTV.visibility = View.VISIBLE
+                    }
                 }
             }
         }

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/model/ADPermissionsRVAdapter.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/model/ADPermissionsRVAdapter.kt
@@ -32,7 +32,7 @@ class ADPermissionsRVAdapter :
         holder.binding.apply {
             permissionTitleTV.text = app.permission
             permissionSubTitleTV.text = app.label.replaceFirstChar { it.uppercase() }
-            if (app.description == "Null" || app.description == "null" || app.description == "") {
+            if (app.description.isNullOrEmpty() || app.description == "null") {
                 permissionDescTV.visibility = View.GONE
                 expandBT.visibility = View.GONE
             } else {

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/PackageManagerModule.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/PackageManagerModule.kt
@@ -88,43 +88,39 @@ object PackageManagerModule {
         permissionList: MutableList<String>,
         packageManager: PackageManager
     ): List<Permission> {
-        val androidPerm = "android.permission."
-        // Filter list to only keep platform permissions
-        val filteredList = permissionList.filter {
-            it.startsWith(androidPerm)
-        }
-
-        // Remove prefix as we only have platform permissions remaining
-        val list = filteredList.map {
-            it.replace("[^>]*permission\\.".toRegex(), "")
-        }
-
+        val list = permissionList
         val permsList = mutableListOf<Permission>()
         list.forEach {
             var permInfo: PermissionInfo? = null
             try {
                 permInfo = packageManager.getPermissionInfo(
-                    "$androidPerm$it",
+                    "$it",
                     PackageManager.GET_META_DATA
                 )
             } catch (exception: PackageManager.NameNotFoundException) {
                 Log.d(TAG, "Unable to find info about $it")
             }
-
             val label = permInfo?.loadLabel(packageManager).toString()
-            val desc = permInfo?.loadDescription(packageManager).toString()
 
             // Labels and desc can be null for undocumented permissions, filter them out
-            if (!label.startsWith(androidPerm) && desc != "null") {
+            if (label != "null") {
                 permsList.add(
                     Permission(
-                        it,
+                        it.replace("[^>]*[a-z][.]".toRegex(), ""),
                         permInfo?.loadLabel(packageManager).toString(),
                         permInfo?.loadDescription(packageManager).toString(),
                     )
                 )
+            } else {
+                permsList.add(
+                    Permission(
+                        it.replace("[^>]*[a-z][.]".toRegex(), ""),
+                        it,
+                    )
+                )
             }
         }
+        permsList.sortBy { it.permission }
         return permsList
     }
 }

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/PackageManagerModule.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/PackageManagerModule.kt
@@ -94,7 +94,7 @@ object PackageManagerModule {
             var permInfo: PermissionInfo? = null
             try {
                 permInfo = packageManager.getPermissionInfo(
-                    "$it",
+                    it,
                     PackageManager.GET_META_DATA
                 )
             } catch (exception: PackageManager.NameNotFoundException) {


### PR DESCRIPTION
- Fix regex to show all permissions and description
- Sort permissions by name
- Hide expand button if description about permission is null
- If permission doesn't have label or description we show permission after regex like title and full permission like subtitle
