### PR TITLE
app: Add new text when 2 versionName is same on AppDetailFragment

### DIFF
--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/AppDetailFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/AppDetailFragment.kt
@@ -130,6 +130,11 @@ class AppDetailFragment : Fragment(R.layout.fragment_app_detail) {
                             visibility = View.VISIBLE
                             text = app.exodusVersionName
                         }
+                        if (app.versionName != app.exodusVersionName) {
+                            appSameVersionTV.visibility = View.GONE
+                        } else {
+                            appSameVersionTV.visibility = View.VISIBLE
+                        }
                     }
                 }
                 if (app.updated.isNotBlank()) {

--- a/app/src/main/res/layout/fragment_app_detail.xml
+++ b/app/src/main/res/layout/fragment_app_detail.xml
@@ -181,6 +181,16 @@
                 android:textColor="?android:textColorPrimary"
                 android:textSize="17sp"
                 tools:text="3.0.0" />
+            
+            <TextView
+              android:id="@+id/appSameVersionTV"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:layout_below="@+id/appVersionTV"
+              android:layout_marginTop="10dp"
+              android:text="@string/same_version"
+              android:textSize="15sp"
+              android:visibility="gone"/>
 
             <TextView
                 android:id="@+id/appReportTV"

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -72,7 +72,8 @@
     <string name="report_date">Rapport créé le <xliff:g id="date">%1$s</xliff:g></string>
     <string name="installed_version">Version installée</string>
     <string name="analyzed_version">Version analysée</string>
-	<string name="learn_more">En savoir plus…</string>
+    <string name="same_version">La même version de l\'application peut être différente suivant la version d\'Android et l\'appareil utilisé.</string>
+    <string name="learn_more">En savoir plus…</string>
 
     <!-- ADTrackers Fragment -->
     <string name="code_signature_found">Nous avons trouvé la signature des pisteurs suivants dans cette application:</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,6 +76,7 @@
     <string name="report_date">Report created on <xliff:g id="date">%1$s</xliff:g></string>
     <string name="installed_version">Installed Version</string>
     <string name="analyzed_version">Analyzed Version</string>
+    <string name="same_version">Same app version may be different following Android version and device used.</string>
     <string name="learn_more">Learn more…</string>
 
     <!-- ADTrackers Fragment -->


### PR DESCRIPTION
Some app have same versionName (app.versionName = report.versionName) on AppDetailFragment but versionCode is different.

To explain why Exodus say report mismatch with app installed.

- I have add new text `Same app version may be different following Android version and device used.` only if report mismatch and report.versionName is equal app.versionName