### PR TITLE
Improved apps, trackers and permissions sorting

### DIFF
--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/database/app/ExodusApplicationDao.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/database/app/ExodusApplicationDao.kt
@@ -15,9 +15,9 @@ interface ExodusApplicationDao {
     @Query("SELECT * FROM exodusapplication WHERE packageName=:packageName")
     suspend fun getApp(packageName: String): List<ExodusApplication>
 
-    @Query("SELECT * FROM exodusapplication WHERE packageName IN (:listOfPackages) ORDER BY name")
+    @Query("SELECT * FROM exodusapplication WHERE packageName IN (:listOfPackages) ORDER BY name COLLATE NOCASE")
     suspend fun getApps(listOfPackages: List<String>): List<ExodusApplication>
 
-    @Query("SELECT * FROM exodusapplication ORDER BY name")
+    @Query("SELECT * FROM exodusapplication ORDER BY name COLLATE NOCASE")
     fun getAllApps(): LiveData<List<ExodusApplication>>
 }

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/database/tracker/TrackerDataDao.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/database/tracker/TrackerDataDao.kt
@@ -19,7 +19,7 @@ interface TrackerDataDao {
     @Query("SELECT * FROM trackerdata WHERE presentOnDevice = 1")
     fun getAllTrackers(): LiveData<List<TrackerData>>
 
-    @Query("SELECT * FROM trackerdata WHERE id IN (:listOfID) ORDER BY name")
+    @Query("SELECT * FROM trackerdata WHERE id IN (:listOfID) ORDER BY name COLLATE NOCASE")
     suspend fun getTrackers(listOfID: List<Int>): List<TrackerData>
 
     @Delete

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/PackageManagerModule.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/PackageManagerModule.kt
@@ -120,7 +120,7 @@ object PackageManagerModule {
                 )
             }
         }
-        permsList.sortBy { it.permission }
+        permsList.sortWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.permission })
         return permsList
     }
 }


### PR DESCRIPTION
Improved default sorting with remove case sensitive on:
- apps name 
- trackers name 
- permissions name

@J-Jamet I don't have find how sorting correctly when apps  name have accents.

Tested on :
- Pixel 6 - Android 12 ✅
- Honor 8 - Android 8 ✅
- Pixel 5 - Android 5 (Emulator) ✅