### PR TITLE
Reports and trackers are never download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           echo "${{secrets.RELEASE_KEYSTORE}}" > release.keystore.asc
           gpg -d --passphrase "${{secrets.RELEASE_KEYSTORE_PGP_PASSPHRASE}}" --batch release.keystore.asc > app/release.keystore
       - name: Generate release build
-        run: ./gradlew assemble
+        run: ./gradlew assembleRelease
       - name: Execute exodus-standalone
         uses: docker://exodusprivacy/exodus-standalone:v1.3.2
         with:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,9 +28,6 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled true
-            shrinkResources true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.releaseConfig
         }
     }


### PR DESCRIPTION
Origin of the problem is type of one variable is incorrect in Exodus Service.
When gradle use optimizations to reduce size app. App doesn't work. She never download trackers and reports.
Remove there optimizations is temporarily.

The correction is already tested.