### PR TITLE
Improve spacing between text in permissions sub fragment and trackers sub fragment

### DIFF
--- a/app/src/main/res/layout/fragment_a_d_permissions.xml
+++ b/app/src/main/res/layout/fragment_a_d_permissions.xml
@@ -40,6 +40,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@+id/permissionsTitleTV"
+        android:layout_marginTop="5dp"
         android:text="@string/code_permission_not_found"
         android:textSize="15sp" />
 
@@ -55,7 +56,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@+id/permissionsRV"
-        android:layout_marginTop="10dp"
+        android:layout_marginTop="15dp"
         android:text="@string/permission_info_dangerous"
         android:textSize="15sp" />
 
@@ -72,7 +73,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@+id/permissionsLearnGoogleTV"
-        android:layout_marginTop="10dp"
+        android:layout_marginTop="15dp"
         android:text="@string/permission_info"
         android:textSize="15sp" />
 

--- a/app/src/main/res/layout/fragment_a_d_trackers.xml
+++ b/app/src/main/res/layout/fragment_a_d_trackers.xml
@@ -37,6 +37,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@+id/trackerTitleTV"
+        android:layout_marginTop="5dp"
         android:text="@string/code_signature_not_found"
         android:textSize="15sp" />
 
@@ -52,7 +53,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@+id/trackersRV"
-        android:layout_marginTop="10dp"
+        android:layout_marginTop="15dp"
         android:text="@string/tracker_info"
         android:textSize="15sp" />
 


### PR DESCRIPTION
| Before | After |
|---|---|
|<img src="https://user-images.githubusercontent.com/87148630/202028374-ea81b5c9-a6c5-4606-9632-3b3bb0da8370.png" height=400 /> | <img src="https://user-images.githubusercontent.com/87148630/202028210-74595b3c-5a29-456a-96bc-06a4ac93038c.png" height=400 /> |
| <img src="https://user-images.githubusercontent.com/87148630/202028610-60efead3-989e-45bf-9ff1-76a32536c553.png" height=400 /> | <img src="https://user-images.githubusercontent.com/87148630/202028710-856742dc-581f-43da-bb62-8b1f54cbb551.png" height=400 />

@jfoucry have ask to increase spacing in permissions and trackers tab.

If it's not enough, i can increase again :)


