### PR TITLE
Reduce short description size

### DIFF
--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Exodus helps you to know which trackers and permissions are embedded in apps installed on your device.
+Exodus show you trackers and permissions in apps installed on your device.

--- a/fastlane/metadata/android/fr-FR/short_description.txt
+++ b/fastlane/metadata/android/fr-FR/short_description.txt
@@ -1,1 +1,1 @@
-Exodus vous aide à savoir quels sont les pisteurs et permissions embarqués dans les applications installées sur votre smartphone.
+Exodus vous montre les pisteurs et permissions des app de votre smartphone.

--- a/fastlane/metadata/android/fr-FR/short_description.txt
+++ b/fastlane/metadata/android/fr-FR/short_description.txt
@@ -1,1 +1,1 @@
-Exodus vous montre les pisteurs et permissions des app de votre smartphone.
+Exodus vous montre les pisteurs et permissions des apps de votre smartphone.


### PR DESCRIPTION
# Goal

- Reduce `fr-FR` and `en-US` short description size according to [F-Droid informations](https://f-droid.org/en/docs/All_About_Descriptions_Graphics_and_Screenshots/).

Fix #204 