### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,4 +46,4 @@ jobs:
         run: gh release create ${{ github.ref }} --generate-notes
       - name: Upload APK on release
         if: github.event_name == 'push' && github.ref_type == 'tag'
-        run: gh release upload ${{ github.ref }} app/build/outputs/apk/release/app-release.apk#exodus-android-app_${{ github.ref }}
+        run: gh release upload ${{ github.ref_name }} app/build/outputs/apk/release/app-release.apk#exodus-android-app_${{ github.ref_name }}


### PR DESCRIPTION
This PR fixed apk upload on release, detected during 3.0.0 release and 3.0.1 release.
Variables environnements used is not correct --> https://github.com/Exodus-Privacy/exodus-android-app/actions/runs/3877667004/jobs/6612948959#step:10:2
Github wait a tag to upload not a path https://cli.github.com/manual/gh_release_upload