### PR TITLE
Remove network config in Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3
+      - name: Remove network security config
+        run: |
+          rm ./app/src/main/res/xml/network_security_config.xml
       - name: Setup Java JDK
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3
+      - name: Remove network security config
+        run: |
+          rm ./app/src/main/res/xml/network_security_config.xml
       - name: Setup Java JDK
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
network_security_config.xml is only use, to execute integration tests in local
Keep this file can broke access to Internet, remove file is more safe to be sure app can get reports and trackers from Exodus server
(Need to do same thing on fdroid metadata file)