### PR TITLE
Fix deprecations

### DIFF
--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/packageinfo/ExodusPackageRepository.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/packageinfo/ExodusPackageRepository.kt
@@ -130,7 +130,6 @@ class ExodusPackageRepository @Inject constructor(
         }
     }
 
-
     private fun getAppStore(packageName: String, packageManager: PackageManager): Source {
         val appStore = packageManager.getSource(packageName)
         Log.d(TAG, "Found AppStore: $appStore for app: $packageName.")

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/packageinfo/ExodusPackageRepository.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/packageinfo/ExodusPackageRepository.kt
@@ -152,13 +152,4 @@ class ExodusPackageRepository @Inject constructor(
             ) &&
             appInfo.enabled
     }
-
-    private fun PackageManager.getInstalledPackagesList(flags: Int): List<PackageInfo> {
-        return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-            this.getInstalledPackages(flags)
-        } else {
-            val newFlags = PackageManager.PackageInfoFlags.of(flags.toLong())
-            this.getInstalledPackages(newFlags)
-        }
-    }
 }

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/packageinfo/ExodusPackageRepository.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/packageinfo/ExodusPackageRepository.kt
@@ -52,7 +52,7 @@ class ExodusPackageRepository @Inject constructor(
     }
 
     fun getValidPackageList(): MutableList<PackageInfo> {
-        val packageList = packageManager.getInstalledPackages(PackageManager.GET_PERMISSIONS)
+        val packageList = packageManager.getInstalledPackagesList(PackageManager.GET_PERMISSIONS)
         val validPackages = mutableListOf<PackageInfo>()
         packageList.forEach { pkgInfo ->
             if (validPackage(pkgInfo, packageManager)) {
@@ -155,5 +155,14 @@ class ExodusPackageRepository @Inject constructor(
                 packageManager.getLaunchIntentForPackage(packageName) != null
             ) &&
             appInfo.enabled
+    }
+
+    private fun PackageManager.getInstalledPackagesList(flags: Int): List<PackageInfo> {
+        return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            this.getInstalledPackages(flags)
+        } else {
+            val newFlags = PackageManager.PackageInfoFlags.of(flags.toLong())
+            this.getInstalledPackages(newFlags)
+        }
     }
 }

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/packageinfo/ExodusPackageRepository.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/packageinfo/ExodusPackageRepository.kt
@@ -4,7 +4,6 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.content.pm.PermissionInfo
-import android.os.Build
 import android.util.Log
 import androidx.core.content.pm.PackageInfoCompat
 import androidx.core.graphics.drawable.toBitmap
@@ -14,10 +13,12 @@ import org.eu.exodus_privacy.exodusprivacy.objects.Application
 import org.eu.exodus_privacy.exodusprivacy.objects.Permission
 import org.eu.exodus_privacy.exodusprivacy.objects.Source
 import org.eu.exodus_privacy.exodusprivacy.utils.IoDispatcher
+import org.eu.exodus_privacy.exodusprivacy.utils.getInstalledPackagesList
+import org.eu.exodus_privacy.exodusprivacy.utils.getSource
 import javax.inject.Inject
 
 class ExodusPackageRepository @Inject constructor(
-    val packageManager: PackageManager,
+    private val packageManager: PackageManager,
     @IoDispatcher val ioDispatcher: CoroutineDispatcher
 ) {
     private val TAG = ExodusPackageRepository::class.java.simpleName

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/packageinfo/ExodusPackageRepository.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/packageinfo/ExodusPackageRepository.kt
@@ -129,13 +129,9 @@ class ExodusPackageRepository @Inject constructor(
         }
     }
 
-    @Suppress("DEPRECATION")
+
     private fun getAppStore(packageName: String, packageManager: PackageManager): Source {
-        val appStore = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            packageManager.getInstallSourceInfo(packageName).installingPackageName
-        } else {
-            packageManager.getInstallerPackageName(packageName)
-        }
+        val appStore = packageManager.getSource(packageName)
         Log.d(TAG, "Found AppStore: $appStore for app: $packageName.")
         return when (appStore) {
             GOOGLE_PLAY_STORE -> Source.GOOGLE

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/CommonExtensions.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/CommonExtensions.kt
@@ -1,6 +1,9 @@
 package org.eu.exodus_privacy.exodusprivacy.utils
 
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
 import android.content.res.ColorStateList
+import android.os.Build
 import android.widget.Toast
 import androidx.core.content.ContextCompat
 import com.google.android.material.chip.Chip
@@ -56,5 +59,24 @@ fun Chip.setVersionReport(app: ExodusApplication) {
             ),
             Toast.LENGTH_LONG
         ).show()
+    }
+}
+
+fun PackageManager.getInstalledPackagesList(flags: Int): List<PackageInfo> {
+    return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+        @Suppress("DEPRECATION")
+        this.getInstalledPackages(flags)
+    } else {
+        val newFlags = PackageManager.PackageInfoFlags.of(flags.toLong())
+        this.getInstalledPackages(newFlags)
+    }
+}
+
+fun PackageManager.getSource(packageName: String): String? {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        this.getInstallSourceInfo(packageName).installingPackageName
+    } else {
+        @Suppress("DEPRECATION")
+        this.getInstallerPackageName(packageName)
     }
 }


### PR DESCRIPTION
This is targeting the deprecations introduced with the update to API 33.

* Create extension functions taking care to call the appropriate PackageManager method
* Update tests accordingly
* Little bit of test clean up