### PR TITLE
Api 33

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -3,4 +3,5 @@
     <color name="colorAccentTheme">#232225</color>
     <color name="colorGrey">#262626</color>
     <color name="chipColor">#4A4458</color>
+    <color name="chipIconTintColor">#f2f2f2</color>
 </resources>

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -3,6 +3,7 @@
 
     <!-- Inherit base theme to allow overriding Dark Theme as per API levels -->
     <style name="Theme.Exodus.Dark" parent="BaseTheme">
+        <item name="chipIconTint">@color/textColorLikeWhite</item>
         <item name="elevationOverlayEnabled">false</item>
         <item name="android:navigationBarColor">@color/colorAccentTheme</item>
         <item name="bottomNavigationStyle">@style/Theme.BottomNavigation.Dark</item>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,6 +7,7 @@
     <color name="colorBackgroundTile">#d6c8db</color>
     <color name="indicatorColor">#66684971</color>
     <color name="chipColor">#E8DEF8</color>
+    <color name="chipIconTintColor">#343A40</color>
     <color name="percent">#77684971</color>
 
     <color name="colorGreen">#6fc384</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -11,9 +11,9 @@
 
     <style name="Theme.Exodus.Chip" parent="Widget.Material3.Chip.Suggestion.Elevated">
         <item name="android:layout_marginEnd">5dp</item>
-        <item name="android:textColor">@color/m3_chip_text_color</item>
+        <item name="android:textColor">@color/chipIconTintColor</item>
         <item name="chipBackgroundColor">@color/chipColor</item>
-        <item name="chipIconTint">@color/m3_chip_text_color</item>
+        <item name="chipIconTint">@color/chipIconTintColor</item>
         <item name="chipCornerRadius">50dp</item>
         <item name="chipIconVisible">true</item>
         <item name="android:checkable">false</item>


### PR DESCRIPTION
@color/m3_chip_text_color was marked private in material 1.9.0.
So a default color was used, which broke the style of the chip.
Add light/dark theme specific colors for chip text color and icon.