### PR TITLE
Bump setup-java to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,9 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v3
       - name: Setup Java JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: 17
       - name: Run Kotlin Linter
         run: ./gradlew app:ktlintCheck --info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,9 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v3
       - name: Setup Java JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: 17
       - name: Decode Keystore
         run: |


### PR DESCRIPTION
Bump setup-java to v3 because, v1 use Node.js 12 (this version is deprecated).
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/