### PR TITLE
fixed issue: migrate to ksp annotation processor

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.android.application")
     id("kotlin-android")
-    id("kotlin-kapt")
+    id("com.google.devtools.ksp")
     id("dagger.hilt.android.plugin")
     id("androidx.navigation.safeargs.kotlin")
     id("org.jlleitschuh.gradle.ktlint")
@@ -21,12 +21,11 @@ android {
         testInstrumentationRunner = "org.eu.exodus_privacy.exodusprivacy.ExodusTestRunner"
         val API_KEY = System.getenv("EXODUS_API_KEY")
         buildConfigField("String", "EXODUS_API_KEY", "\"$API_KEY\"")
-        javaCompileOptions {
-            annotationProcessorOptions {
-                compilerArgumentProviders(
-                    RoomSchemaArgProvider(File(projectDir, "schemas"))
-                )
-            }
+
+        ksp {
+            arg(
+                RoomSchemaArgProvider(File(projectDir, "schemas")),
+            )
         }
 
         signingConfigs {
@@ -87,9 +86,6 @@ android {
         generateLocaleConfig = true
     }
 }
-kapt {
-    correctErrorTypes = true
-}
 
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
@@ -127,7 +123,7 @@ dependencies {
     implementation(libs.okhttp)
 
     // Hilt
-    kapt(libs.dagger.hilt.compiler)
+    ksp(libs.dagger.hilt.compiler)
     implementation(libs.dagger.hilt.android)
 
     // Lifecycle
@@ -136,7 +132,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.service)
 
     // Room
-    kapt(libs.androidx.room.compiler)
+    ksp(libs.androidx.room.compiler)
     implementation(libs.androidx.room.ktx)
     implementation(libs.androidx.room.runtime)
 
@@ -153,10 +149,10 @@ dependencies {
     testImplementation(libs.androidx.test.rules)
     testImplementation(libs.dagger.hilt.android.testing)
     testImplementation(libs.okhttp.mockwebserver)
-    kaptTest(libs.dagger.hilt.compiler)
+    kspTest(libs.dagger.hilt.compiler)
 
     // instrumentation tests
-    kaptAndroidTest(libs.dagger.hilt.compiler)
+    kspAndroidTest(libs.dagger.hilt.compiler)
     androidTestImplementation(libs.dagger.hilt.android.testing)
     androidTestImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.androidx.test.core.ktx)
@@ -171,7 +167,7 @@ dependencies {
 class RoomSchemaArgProvider(
     @get:InputDirectory
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    val schemaDir: File
+    val schemaDir: File,
 ) : CommandLineArgumentProvider {
     override fun asArguments() = listOf("room.schemaLocation=${schemaDir.path}")
 }

--- a/app/schemas/org.eu.exodus_privacy.exodusprivacy.manager.database.ExodusDatabase/2.json
+++ b/app/schemas/org.eu.exodus_privacy.exodusprivacy.manager.database.ExodusDatabase/2.json
@@ -77,10 +77,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "id"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": []
@@ -169,10 +169,10 @@
           }
         ],
         "primaryKey": {
+          "autoGenerate": false,
           "columnNames": [
             "packageName"
-          ],
-          "autoGenerate": false
+          ]
         },
         "indices": [],
         "foreignKeys": []

--- a/app/src/androidTest/java/org/eu/exodus_privacy/exodusprivacy/ExodusDatabaseRepositoryTest.kt
+++ b/app/src/androidTest/java/org/eu/exodus_privacy/exodusprivacy/ExodusDatabaseRepositoryTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.res.AssetManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.util.Log
 import androidx.core.graphics.scale
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
@@ -12,6 +13,7 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.eu.exodus_privacy.exodusprivacy.manager.database.ExodusDatabase
+import org.eu.exodus_privacy.exodusprivacy.manager.database.ExodusDatabaseConverters
 import org.eu.exodus_privacy.exodusprivacy.manager.database.ExodusDatabaseRepository
 import org.eu.exodus_privacy.exodusprivacy.manager.database.app.ExodusApplication
 import org.eu.exodus_privacy.exodusprivacy.manager.database.tracker.TrackerData
@@ -40,6 +42,7 @@ class ExodusDatabaseRepositoryTest {
     private lateinit var image: Bitmap
     private lateinit var testDB: ExodusDatabase
     private lateinit var exodusDatabaseRepository: ExodusDatabaseRepository
+    private lateinit var exodusTypeConverter: ExodusDatabaseConverters
 
     private val packageName = "com.test.testapp"
     private val packageName2 = "com.test.testapp2"
@@ -64,11 +67,12 @@ class ExodusDatabaseRepositoryTest {
         assets = context.assets
         bitmapStream = assets.open("mipmap/big_square_bigfs.png")
         image = BitmapFactory.decodeStream(bitmapStream)
+        exodusTypeConverter = ExodusDatabaseConverters()
 
         testDB = Room.inMemoryDatabaseBuilder(
             context,
             ExodusDatabase::class.java
-        ).build()
+        ).addTypeConverter(exodusTypeConverter).build()
 
         exodusDatabaseRepository = ExodusDatabaseRepository(
             testDB,

--- a/app/src/androidTest/java/org/eu/exodus_privacy/exodusprivacy/ExodusDatabaseRepositoryTest.kt
+++ b/app/src/androidTest/java/org/eu/exodus_privacy/exodusprivacy/ExodusDatabaseRepositoryTest.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.res.AssetManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.util.Log
 import androidx.core.graphics.scale
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/database/ExodusDatabase.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/database/ExodusDatabase.kt
@@ -18,8 +18,8 @@ import org.eu.exodus_privacy.exodusprivacy.objects.Constants
         AutoMigration(
             from = Constants.previousDatabaseVersion,
             to = Constants.currentDatabaseVersion,
-        ),
-    ],
+        )
+    ]
 )
 @TypeConverters(ExodusDatabaseConverters::class)
 abstract class ExodusDatabase : RoomDatabase() {

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/database/ExodusDatabase.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/database/ExodusDatabase.kt
@@ -17,9 +17,9 @@ import org.eu.exodus_privacy.exodusprivacy.objects.Constants
     autoMigrations = [
         AutoMigration(
             from = Constants.previousDatabaseVersion,
-            to = Constants.currentDatabaseVersion
-        )
-    ]
+            to = Constants.currentDatabaseVersion,
+        ),
+    ],
 )
 @TypeConverters(ExodusDatabaseConverters::class)
 abstract class ExodusDatabase : RoomDatabase() {

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/database/ExodusDatabaseConverters.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/database/ExodusDatabaseConverters.kt
@@ -2,12 +2,14 @@ package org.eu.exodus_privacy.exodusprivacy.manager.database
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import androidx.room.ProvidedTypeConverter
 import androidx.room.TypeConverter
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import org.eu.exodus_privacy.exodusprivacy.objects.Permission
 import java.io.ByteArrayOutputStream
 
+@ProvidedTypeConverter
 class ExodusDatabaseConverters {
 
     @TypeConverter
@@ -18,6 +20,17 @@ class ExodusDatabaseConverters {
 
     @TypeConverter
     fun fromStringList(list: List<String>): String {
+        return Gson().toJson(list)
+    }
+
+    @TypeConverter
+    fun toMutableStringList(string: String): MutableList<String> {
+        val listType = object : TypeToken<MutableList<String>>() {}.type
+        return Gson().fromJson(string, listType)
+    }
+
+    @TypeConverter
+    fun fromMutableStringList(list: MutableList<String>): String {
         return Gson().toJson(list)
     }
 

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/database/ExodusDatabaseModule.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/database/ExodusDatabaseModule.kt
@@ -14,10 +14,12 @@ import javax.inject.Singleton
 object ExodusDatabaseModule {
 
     private const val DATABASE_NAME = "exodus_database"
+    private val exodusTypeConverter = ExodusDatabaseConverters()
 
     @Singleton
     @Provides
     fun provideExodusDatabaseInstance(@ApplicationContext context: Context): ExodusDatabase {
-        return Room.databaseBuilder(context, ExodusDatabase::class.java, DATABASE_NAME).build()
+        return Room.databaseBuilder(context, ExodusDatabase::class.java, DATABASE_NAME)
+            .addTypeConverter(exodusTypeConverter).build()
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.androidx.navigation.safeargs.kotlin) apply false
     alias(libs.plugins.dagger.hilt.android) apply false
     alias(libs.plugins.gradle.ktlint) apply false
+    alias(libs.plugins.kotlin.ksp) apply false
 }
 
 tasks.register("clean", Delete::class) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ runner = "1.5.2"
 shimmer = "0.5.0"
 swiperefreshlayout = "1.1.0"
 window = "1.1.0"
+ksp = "1.8.22-1.0.11"
 
 [libraries]
 androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activity-ktx" }
@@ -95,3 +96,4 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinPlu
 androidx-navigation-safeargs-kotlin = { id = "androidx.navigation.safeargs.kotlin", version.ref = "navigation-fragment-ktx" }
 dagger-hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "dagger-hilt" }
 gradle-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "gradleKtlint" }
+kotlin-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp"}


### PR DESCRIPTION
#322 
- Added the version and lib in lib.versions.toml
- Replaced kapt with ksp
- Replaced javaCompileOptions with ksp
- Added type converter for MutableList<String>
- Passed an instance of the type converters class to the Room Database Builder