### PR TITLE
Fix cuttered icon in splashscreen

### DIFF
--- a/app/src/main/res/drawable/splash_inset.xml
+++ b/app/src/main/res/drawable/splash_inset.xml
@@ -1,0 +1,7 @@
+<inset
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:drawable="@drawable/ic_launcher_foreground"
+  android:insetLeft="5dp"
+  android:insetTop="5dp"
+  android:insetRight="5dp"
+  android:insetBottom="5dp" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -20,7 +20,7 @@
     </style>
 
     <style name="Theme.Exodus.Splash" parent="Theme.SplashScreen">
-        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/splash_inset</item>
         <item name="postSplashScreenTheme">@style/Theme.Exodus</item>
     </style>
 


### PR DESCRIPTION
This PR add an inset around the app icon to not have cutter border of icons in splashcreen (Only reproduced on Samsung Galaxy Tab S6 Lite).

|Before|After|
|-|-|
|<img src="https://github.com/Exodus-Privacy/exodus-android-app/assets/87148630/9c6ce4a4-1268-4492-be64-3b9c440117d7" height=300 />|<img src="https://github.com/Exodus-Privacy/exodus-android-app/assets/87148630/f80c002e-a657-4c57-b881-73974c5de9a3" height=300 />|
