### PR TITLE
Fix crash on devices without browsers support custom tabs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,5 +41,9 @@
             android:name=".ExodusUpdateService"
             android:exported="false" />
     </application>
-
+    <queries>
+        <intent>
+            <action android:name="android.support.customtabs.action.CustomTabsService" />
+        </intent>
+    </queries>
 </manifest>

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/about/AboutFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/about/AboutFragment.kt
@@ -18,6 +18,7 @@ import org.eu.exodus_privacy.exodusprivacy.R
 import org.eu.exodus_privacy.exodusprivacy.databinding.FragmentAboutBinding
 import org.eu.exodus_privacy.exodusprivacy.fragments.dialog.ThemeDialogFragment
 import org.eu.exodus_privacy.exodusprivacy.utils.getLanguage
+import org.eu.exodus_privacy.exodusprivacy.utils.openURL
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -98,43 +99,42 @@ class AboutFragment : PreferenceFragmentCompat() {
         setPreferencesFromResource(R.xml.about_preference, rootKey)
 
         findPreference<Preference>("analyze")?.setOnPreferenceClickListener {
-            customTabsIntent.launchUrl(it.context, Uri.parse(analyzeURL))
+            openURL(customTabsIntent, it.context, analyzeURL)
             true
         }
 
         findPreference<Preference>("alternatives")?.setOnPreferenceClickListener {
-            customTabsIntent.launchUrl(it.context, Uri.parse(alternativesURL))
+            openURL(customTabsIntent, it.context, alternativesURL)
             true
         }
 
         findPreference<Preference>("website")?.setOnPreferenceClickListener {
-            customTabsIntent.launchUrl(it.context, Uri.parse(getLocaleWebsiteURL()))
+            openURL(customTabsIntent, it.context, getLocaleWebsiteURL())
             true
         }
         findPreference<Preference>("privPolicy")?.setOnPreferenceClickListener {
-            customTabsIntent.launchUrl(it.context, Uri.parse(privacyPolicyURL))
+            openURL(customTabsIntent, it.context, privacyPolicyURL)
             true
         }
 
         findPreference<Preference>("srcCode")?.setOnPreferenceClickListener {
-            customTabsIntent.launchUrl(it.context, Uri.parse(sourceCodeURL))
+            openURL(customTabsIntent, it.context, sourceCodeURL)
             true
         }
 
         findPreference<Preference>("X")?.setOnPreferenceClickListener {
-            customTabsIntent.launchUrl(it.context, Uri.parse(twitterURL))
+            openURL(customTabsIntent, it.context, twitterURL)
             true
         }
 
         findPreference<Preference>("mastodon")?.setOnPreferenceClickListener {
-            customTabsIntent.launchUrl(it.context, Uri.parse(mastodonURL))
+            openURL(customTabsIntent, it.context, mastodonURL)
             true
         }
 
         // Open default email app for support
         findPreference<Preference>("email")?.setOnPreferenceClickListener {
-            val intent = Intent(Intent.ACTION_VIEW)
-            intent.data = Uri.parse("mailto:$emailID")
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse("mailto:$emailID"))
             try {
                 startActivity(intent)
                 true

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/AppDetailFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/AppDetailFragment.kt
@@ -1,6 +1,5 @@
 package org.eu.exodus_privacy.exodusprivacy.fragments.appdetail
 
-import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -21,6 +20,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.eu.exodus_privacy.exodusprivacy.R
 import org.eu.exodus_privacy.exodusprivacy.databinding.FragmentAppDetailBinding
 import org.eu.exodus_privacy.exodusprivacy.fragments.appdetail.model.AppDetailVPAdapter
+import org.eu.exodus_privacy.exodusprivacy.utils.openURL
 import org.eu.exodus_privacy.exodusprivacy.utils.setExodusColor
 import javax.inject.Inject
 
@@ -76,29 +76,25 @@ class AppDetailFragment : Fragment(R.layout.fragment_app_detail) {
                     setOnMenuItemClickListener {
                         when (it.itemId) {
                             R.id.openExodusPage -> {
-                                customTabsIntent.launchUrl(
+                                openURL(
+                                    customTabsIntent,
                                     view.context,
-                                    Uri.parse(exodusReportPage + app.report),
+                                    exodusReportPage + app.report,
                                 )
                             }
                             R.id.submitApp -> {
-                                customTabsIntent.launchUrl(
+                                openURL(
+                                    customTabsIntent,
                                     view.context,
-                                    Uri.parse(exodusSubmitPage + app.packageName),
+                                    exodusSubmitPage + app.packageName,
                                 )
                             }
                             R.id.openStore -> {
-                                try {
-                                    customTabsIntent.launchUrl(
-                                        view.context,
-                                        Uri.parse(storePage + app.packageName),
-                                    )
-                                } catch (e: ActivityNotFoundException) {
-                                    customTabsIntent.launchUrl(
-                                        view.context,
-                                        Uri.parse(GPPage + app.packageName),
-                                    )
-                                }
+                                openURL(
+                                    customTabsIntent,
+                                    view.context,
+                                    storePage + app.packageName,
+                                )
                             }
                             R.id.openAppInfo -> {
                                 val intent =

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/subfrags/ADPermissionsFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/subfrags/ADPermissionsFragment.kt
@@ -1,6 +1,5 @@
 package org.eu.exodus_privacy.exodusprivacy.fragments.appdetail.subfrags
 
-import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.browser.customtabs.CustomTabsIntent
@@ -12,6 +11,7 @@ import org.eu.exodus_privacy.exodusprivacy.R
 import org.eu.exodus_privacy.exodusprivacy.databinding.FragmentADPermissionsBinding
 import org.eu.exodus_privacy.exodusprivacy.fragments.appdetail.AppDetailViewModel
 import org.eu.exodus_privacy.exodusprivacy.fragments.appdetail.model.ADPermissionsRVAdapter
+import org.eu.exodus_privacy.exodusprivacy.utils.openURL
 import org.eu.exodus_privacy.exodusprivacy.utils.setExodusColor
 import javax.inject.Inject
 
@@ -62,18 +62,20 @@ class ADPermissionsFragment : Fragment(R.layout.fragment_a_d_permissions) {
                 permissionsLearnGoogleTV.apply {
                     isClickable = true
                     setOnClickListener {
-                        customTabsIntent.launchUrl(
+                        openURL(
+                            customTabsIntent,
                             view.context,
-                            Uri.parse(googleInfoPage),
+                            googleInfoPage,
                         )
                     }
                 }
                 permissionsLearnExodusTV.apply {
                     isClickable = true
                     setOnClickListener {
-                        customTabsIntent.launchUrl(
+                        openURL(
+                            customTabsIntent,
                             view.context,
-                            Uri.parse(permissionsInfoPage),
+                            permissionsInfoPage,
                         )
                     }
                 }

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/subfrags/ADTrackersFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/subfrags/ADTrackersFragment.kt
@@ -1,6 +1,5 @@
 package org.eu.exodus_privacy.exodusprivacy.fragments.appdetail.subfrags
 
-import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import android.view.View
@@ -14,6 +13,7 @@ import org.eu.exodus_privacy.exodusprivacy.R
 import org.eu.exodus_privacy.exodusprivacy.databinding.FragmentADTrackersBinding
 import org.eu.exodus_privacy.exodusprivacy.fragments.appdetail.AppDetailViewModel
 import org.eu.exodus_privacy.exodusprivacy.fragments.trackers.model.TrackersRVAdapter
+import org.eu.exodus_privacy.exodusprivacy.utils.openURL
 import org.eu.exodus_privacy.exodusprivacy.utils.setExodusColor
 import javax.inject.Inject
 
@@ -55,9 +55,10 @@ class ADTrackersFragment : Fragment(R.layout.fragment_a_d_trackers) {
                 trackersLearnTV.apply {
                     isClickable = true
                     setOnClickListener {
-                        customTabsIntent.launchUrl(
+                        openURL(
+                            customTabsIntent,
                             view.context,
-                            Uri.parse(trackersInfoPage),
+                            trackersInfoPage,
                         )
                     }
                 }

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/trackerdetail/TrackerDetailFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/trackerdetail/TrackerDetailFragment.kt
@@ -1,7 +1,6 @@
 package org.eu.exodus_privacy.exodusprivacy.fragments.trackerdetail
 
 import android.content.res.Configuration
-import android.net.Uri
 import android.os.Bundle
 import android.text.method.LinkMovementMethod
 import android.view.View
@@ -21,6 +20,7 @@ import io.noties.markwon.Markwon
 import org.eu.exodus_privacy.exodusprivacy.R
 import org.eu.exodus_privacy.exodusprivacy.databinding.FragmentTrackerDetailBinding
 import org.eu.exodus_privacy.exodusprivacy.fragments.apps.model.AppsRVAdapter
+import org.eu.exodus_privacy.exodusprivacy.utils.openURL
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -62,9 +62,10 @@ class TrackerDetailFragment : Fragment(R.layout.fragment_tracker_detail) {
                     inflateMenu(R.menu.tracker_detail_menu)
                     setOnMenuItemClickListener {
                         if (it.itemId == R.id.openTrackerPage) {
-                            customTabsIntent.launchUrl(
+                            openURL(
+                                customTabsIntent,
                                 view.context,
-                                Uri.parse(tracker.website),
+                                tracker.website,
                             )
                         }
                         true

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/BrowserUtils.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/BrowserUtils.kt
@@ -1,0 +1,30 @@
+package org.eu.exodus_privacy.exodusprivacy.utils
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsClient
+import androidx.browser.customtabs.CustomTabsIntent
+import java.util.Collections
+
+fun startActivity(context: Context, url: String) {
+    try {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        context.startActivity(intent)
+    } catch (e: ActivityNotFoundException) {
+        false
+    }
+}
+
+fun openURL(customTabsIntent: CustomTabsIntent, context: Context, url: String) {
+    val packageName = CustomTabsClient.getPackageName(
+        context,
+        Collections.emptyList(),
+    )
+    if (packageName != null) {
+        customTabsIntent.launchUrl(context, Uri.parse(url))
+    } else {
+        startActivity(context, url)
+    }
+}


### PR DESCRIPTION
Fixes #286
This PR fix crashes on devices with browser doesn't support custom tab.
- Add new `openURL` method to know if default browser supports custom tabs -> more information here https://developer.chrome.com/docs/android/custom-tabs/howto-custom-tab-check
- Add new `startActivity` method to don't generate crash when devices doesn't have browser, app mail or app store.