### PR TITLE
Fix linter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+# editorconfig.org
+
+root = true
+
+[*.{kt,kts}]
+ktlint_standard_package-name = disabled

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,6 +8,11 @@ plugins {
     id("org.jetbrains.kotlin.android")
 }
 
+configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
+    version.set("0.50.0")
+    android.set(true)
+}
+
 android {
     namespace = "org.eu.exodus_privacy.exodusprivacy"
     compileSdk = 34

--- a/app/src/androidTest/java/org/eu/exodus_privacy/exodusprivacy/DatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/org/eu/exodus_privacy/exodusprivacy/DatabaseMigrationTest.kt
@@ -31,13 +31,13 @@ class DatabaseMigrationTest {
         InstrumentationRegistry.getInstrumentation(),
         ExodusDatabase::class.java,
         listOf(FakeAutoMigrationSpec()),
-        FrameworkSQLiteOpenHelperFactory()
+        FrameworkSQLiteOpenHelperFactory(),
     )
 
     private val MIGRATION_1_2 = object : Migration(1, 2) {
         override fun migrate(database: SupportSQLiteDatabase) {
             database.execSQL(
-                "ALTER TABLE TrackerData ADD COLUMN totalNumberOfAppsHavingTrackers INTEGER NOT NULL DEFAULT 0"
+                "ALTER TABLE TrackerData ADD COLUMN totalNumberOfAppsHavingTrackers INTEGER NOT NULL DEFAULT 0",
             )
         }
     }
@@ -55,7 +55,7 @@ class DatabaseMigrationTest {
                     "source, report, created, updated) " +
                     "VALUES( " +
                     "'TestApp', 'TestApp', 'bitmap', 'TestApp', 'long', 'perms', " +
-                    "'TestApp', 'long', 'tracks', 'source', 0, 'somewhen', 'somewhen' );"
+                    "'TestApp', 'long', 'tracks', 'source', 0, 'somewhen', 'somewhen' );",
             )
             execSQL(
                 "INSERT INTO TrackerData (" +
@@ -63,7 +63,7 @@ class DatabaseMigrationTest {
                     "name, network_signature, website, presentOnDevice," +
                     "exodusApplications) " +
                     "VALUES(0, 'sdf', 'signature', 'date', 'description', 'TestTracker', 'signature'" +
-                    ", 'webaddress.com', 'notTrue', 'mutableStringList');"
+                    ", 'webaddress.com', 'notTrue', 'mutableStringList');",
             )
             // Prepare for the next version.
             close()

--- a/app/src/androidTest/java/org/eu/exodus_privacy/exodusprivacy/ExodusAPIRepositoryTest.kt
+++ b/app/src/androidTest/java/org/eu/exodus_privacy/exodusprivacy/ExodusAPIRepositoryTest.kt
@@ -54,7 +54,7 @@ const val FAKE_RESPONSE =
 @Module
 @TestInstallIn(
     components = [SingletonComponent::class],
-    replaces = [ExodusModule::class]
+    replaces = [ExodusModule::class],
 )
 object FakeExodusModule {
     @Singleton
@@ -129,13 +129,13 @@ class ExodusAPIRepositoryTest {
             try {
                 exodusAPIRepository.getAllTrackers()
             } catch (
-                exception: java.net.SocketTimeoutException
+                exception: java.net.SocketTimeoutException,
             ) {
                 exception
             }
         assertEquals(
             "java.net.SocketTimeoutException: timeout",
-            exception.toString()
+            exception.toString(),
         )
     }
 }

--- a/app/src/androidTest/java/org/eu/exodus_privacy/exodusprivacy/ExodusDataStoreRepositoryTest.kt
+++ b/app/src/androidTest/java/org/eu/exodus_privacy/exodusprivacy/ExodusDataStoreRepositoryTest.kt
@@ -37,7 +37,7 @@ class ExodusDataStoreRepositoryTest {
             stringPreferencesKey("testKey"),
             object : TypeToken<Map<String, ExodusConfig>>() {},
             DataStoreName("testDataStore1"),
-            context
+            context,
         )
 
         // when
@@ -56,12 +56,12 @@ class ExodusDataStoreRepositoryTest {
             stringPreferencesKey("testKey"),
             object : TypeToken<Map<String, ExodusConfig>>() {},
             DataStoreName("testDataStore2"),
-            context
+            context,
         )
 
         val newValues = mapOf(
             "privacy_policy" to ExodusConfig("privacy_policy_consent", true),
-            "notification_perm" to ExodusConfig("notification_requested", true)
+            "notification_perm" to ExodusConfig("notification_requested", true),
         )
 
         // when

--- a/app/src/androidTest/java/org/eu/exodus_privacy/exodusprivacy/ExodusDatabaseRepositoryTest.kt
+++ b/app/src/androidTest/java/org/eu/exodus_privacy/exodusprivacy/ExodusDatabaseRepositoryTest.kt
@@ -70,12 +70,12 @@ class ExodusDatabaseRepositoryTest {
 
         testDB = Room.inMemoryDatabaseBuilder(
             context,
-            ExodusDatabase::class.java
+            ExodusDatabase::class.java,
         ).addTypeConverter(exodusTypeConverter).build()
 
         exodusDatabaseRepository = ExodusDatabaseRepository(
             testDB,
-            testDispatcher
+            testDispatcher,
         )
 
         // when
@@ -92,7 +92,7 @@ class ExodusDatabaseRepositoryTest {
             source,
             report,
             created,
-            updated
+            updated,
         )
 
         exodusAppEntry2 = ExodusApplication(
@@ -108,7 +108,7 @@ class ExodusDatabaseRepositoryTest {
             source,
             report,
             created,
-            updated
+            updated,
         )
 
         exodusTrackerDataEntry = TrackerData(
@@ -119,7 +119,7 @@ class ExodusDatabaseRepositoryTest {
             description = "Lorem Ipsum",
             name = "TestTracker",
             network_signature = "Unknown",
-            website = "example.com"
+            website = "example.com",
         )
 
         exodusTrackerDataEntry2 = TrackerData(
@@ -130,7 +130,7 @@ class ExodusDatabaseRepositoryTest {
             description = "Lorem Ipsum",
             name = "TestTracker2",
             network_signature = "Unknown",
-            website = "example.com"
+            website = "example.com",
         )
     }
 
@@ -156,12 +156,12 @@ class ExodusDatabaseRepositoryTest {
         try {
             exodusDatabaseRepository.getApp(packageName)
         } catch (
-            exception: java.lang.Exception
+            exception: java.lang.Exception,
         ) {
             exceptions.add(exception.toString())
         }
         assert(
-            dataBaseExceptionMessage in exceptions[0] || javaIllegalStateExceptionMessage in exceptions[0]
+            dataBaseExceptionMessage in exceptions[0] || javaIllegalStateExceptionMessage in exceptions[0],
         )
     }
 
@@ -183,7 +183,7 @@ class ExodusDatabaseRepositoryTest {
             source,
             report,
             created,
-            updated
+            updated,
         )
 
         // when
@@ -212,14 +212,14 @@ class ExodusDatabaseRepositoryTest {
             source,
             report,
             created,
-            updated
+            updated,
         )
 
         // when
         exodusDatabaseRepository.saveApp(exodusAppEntry)
         exodusDatabaseRepository.saveApp(exodusAppEntry2)
         val retrievedApp = exodusDatabaseRepository.getApps(
-            listOf(packageName, packageName2)
+            listOf(packageName, packageName2),
         )
 
         // then

--- a/app/src/androidTest/java/org/eu/exodus_privacy/exodusprivacy/ExodusPackageRepositoryTest.kt
+++ b/app/src/androidTest/java/org/eu/exodus_privacy/exodusprivacy/ExodusPackageRepositoryTest.kt
@@ -68,7 +68,7 @@ class ExodusPackageRepositoryTest {
             assert(
                 youtubePackage.requestedPermissions.any {
                     it.contains(perm.longName)
-                }
+                },
             )
         }
     }
@@ -109,7 +109,7 @@ class ExodusPackageRepositoryTest {
         val packageManager = context.packageManager
         val installedApps =
             context.packageManager.getInstalledPackagesList(
-                PackageManager.GET_PERMISSIONS + PackageManager.GET_ACTIVITIES
+                PackageManager.GET_PERMISSIONS + PackageManager.GET_ACTIVITIES,
             )
         var count = 0
 
@@ -121,12 +121,12 @@ class ExodusPackageRepositoryTest {
             comparePkgInfo = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
                 packageManager.getApplicationInfo(
                     pkg.packageName,
-                    0
+                    0,
                 )
             } else {
                 packageManager.getApplicationInfo(
                     pkg.packageName,
-                    PackageManager.ApplicationInfoFlags.of(0.toLong())
+                    PackageManager.ApplicationInfoFlags.of(0.toLong()),
                 )
             }
             val applicationInfoObjectsAreTheSame =

--- a/app/src/androidTest/java/org/eu/exodus_privacy/exodusprivacy/ExodusTestRunner.kt
+++ b/app/src/androidTest/java/org/eu/exodus_privacy/exodusprivacy/ExodusTestRunner.kt
@@ -9,12 +9,12 @@ class ExodusTestRunner : AndroidJUnitRunner() {
     override fun newApplication(
         cl: ClassLoader,
         appName: String,
-        context: Context
+        context: Context,
     ): Application {
         return super.newApplication(
             cl,
             HiltTestApplication::class.java.name,
-            context
+            context,
         )
     }
 }

--- a/app/src/androidTest/java/org/eu/exodus_privacy/exodusprivacy/ExodusUpdateServiceTest.kt
+++ b/app/src/androidTest/java/org/eu/exodus_privacy/exodusprivacy/ExodusUpdateServiceTest.kt
@@ -36,7 +36,7 @@ class ExodusUpdateServiceTest {
 
         val serviceIntent = Intent(
             context,
-            ExodusUpdateService::class.java
+            ExodusUpdateService::class.java,
         )
         serviceRule.startService(serviceIntent)
 
@@ -64,7 +64,7 @@ class ExodusUpdateServiceTest {
 
         val serviceIntent = Intent(
             context,
-            ExodusUpdateService::class.java
+            ExodusUpdateService::class.java,
         )
         serviceRule.startService(serviceIntent)
 
@@ -76,7 +76,7 @@ class ExodusUpdateServiceTest {
                 val appsList = mutableListOf(
                     ExodusApplication(exodusTrackers = listOf(0)),
                     ExodusApplication(exodusTrackers = listOf(1)),
-                    ExodusApplication(exodusTrackers = listOf())
+                    ExodusApplication(exodusTrackers = listOf()),
                 )
 
                 // then

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/ExodusUpdateService.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/ExodusUpdateService.kt
@@ -143,7 +143,7 @@ class ExodusUpdateService : LifecycleService() {
 
             if (ActivityCompat.checkSelfPermission(
                     this,
-                    Manifest.permission.POST_NOTIFICATIONS
+                    Manifest.permission.POST_NOTIFICATIONS,
                 ) == PackageManager.PERMISSION_GRANTED
             ) {
                 Log.d(TAG, "Permission to post notification was granted.")
@@ -160,8 +160,8 @@ class ExodusUpdateService : LifecycleService() {
                         currentSize.value!!,
                         numberOfInstalledPackages,
                         !firstTime,
-                        this
-                    )
+                        this,
+                    ),
                 )
             }
 
@@ -172,7 +172,7 @@ class ExodusUpdateService : LifecycleService() {
                 currentSize.observe(this) { current ->
                     notificationManager.notify(
                         SERVICE_ID,
-                        createNotification(current, numberOfInstalledPackages, false, this)
+                        createNotification(current, numberOfInstalledPackages, false, this),
                     )
                 }
             }
@@ -189,13 +189,13 @@ class ExodusUpdateService : LifecycleService() {
         currentSize: Int,
         totalSize: Int,
         cancellable: Boolean,
-        context: Context
+        context: Context,
     ): Notification {
         val builder = setUpNotification(
             currentSize,
             totalSize,
             cancellable,
-            context
+            context,
         )
         return builder.build()
     }
@@ -204,7 +204,7 @@ class ExodusUpdateService : LifecycleService() {
         currentSize: Int,
         totalSize: Int,
         cancellable: Boolean,
-        context: Context
+        context: Context,
     ): NotificationCompat.Builder {
         val notificationIntent = Intent(context, MainActivity::class.java)
         val notificationPendingIntent: PendingIntent? = TaskStackBuilder.create(context).run {
@@ -216,8 +216,8 @@ class ExodusUpdateService : LifecycleService() {
                 getString(
                     R.string.updating_database,
                     currentSize,
-                    totalSize + 1
-                )
+                    totalSize + 1,
+                ),
             )
             .setProgress(totalSize + 1, currentSize, false)
             .setTimeoutAfter(5000L)
@@ -236,7 +236,7 @@ class ExodusUpdateService : LifecycleService() {
         Toast.makeText(
             this,
             getString(R.string.fetching_apps),
-            Toast.LENGTH_SHORT
+            Toast.LENGTH_SHORT,
         ).show()
         serviceScope.launch {
             if (!firstTime) removeUninstalledApps()
@@ -284,7 +284,7 @@ class ExodusUpdateService : LifecycleService() {
                     value.description,
                     value.name,
                     value.network_signature,
-                    value.website
+                    value.website,
                 )
                 trackersList.add(trackerData)
             }
@@ -332,7 +332,7 @@ class ExodusUpdateService : LifecycleService() {
                     app.source,
                     latestExodusApp.report,
                     latestExodusApp.created,
-                    latestExodusApp.updated
+                    latestExodusApp.updated,
                 )
 
                 appList.add(exodusApp)
@@ -377,7 +377,7 @@ class ExodusUpdateService : LifecycleService() {
     }
 
     fun countAppsHavingTrackers(
-        appList: MutableList<ExodusApplication>
+        appList: MutableList<ExodusApplication>,
     ): Int {
         return appList.count {
             it.exodusTrackers.isNotEmpty()

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/MainActivity.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/MainActivity.kt
@@ -43,7 +43,7 @@ class MainActivity : AppCompatActivity() {
                 Snackbar.make(
                     binding.fragmentCoordinator,
                     R.string.not_connected,
-                    Snackbar.LENGTH_LONG
+                    Snackbar.LENGTH_LONG,
                 ).setAnchorView(binding.bottomNavView) // Snackbar will appear above bottom nav view
                     .setAction(R.string.settings) {
                         try {
@@ -87,7 +87,7 @@ class MainActivity : AppCompatActivity() {
     override fun onRequestPermissionsResult(
         requestCode: Int,
         permissions: Array<out String>,
-        grantResults: IntArray
+        grantResults: IntArray,
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
         viewModel.saveNotificationPermissionRequested(true)
@@ -101,7 +101,7 @@ class MainActivity : AppCompatActivity() {
             ) {
                 Log.d(
                     TAG,
-                    "Populating database for the first time."
+                    "Populating database for the first time.",
                 )
                 val intent = Intent(this, ExodusUpdateService::class.java)
                 intent.apply {

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/MainActivityViewModel.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/MainActivityViewModel.kt
@@ -15,7 +15,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MainActivityViewModel @Inject constructor(
     private val configStorage: ExodusDataStoreRepository<ExodusConfig>,
-    private val networkManager: NetworkManager
+    private val networkManager: NetworkManager,
 ) : ViewModel() {
     init {
         networkManager.checkConnection()

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/about/AboutFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/about/AboutFragment.kt
@@ -87,7 +87,7 @@ class AboutFragment : PreferenceFragmentCompat() {
             getString(
                 R.string.version_info,
                 BuildConfig.VERSION_NAME,
-                BuildConfig.VERSION_CODE
+                BuildConfig.VERSION_CODE,
             )
         binding.appVersionTV.setOnClickListener {
             Toast.makeText(context, "Thanks for support ❤", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/AppDetailFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/AppDetailFragment.kt
@@ -69,31 +69,34 @@ class AppDetailFragment : Fragment(R.layout.fragment_app_detail) {
                     inflateMenu(R.menu.app_detail_menu)
                     if (app.exodusVersionCode == 0L) {
                         menu.findItem(R.id.openExodusPage)?.isVisible = false
-                    } else menu.findItem(R.id.submitApp)?.isVisible = app.exodusVersionCode != app.versionCode
+                    } else {
+                        menu.findItem(R.id.submitApp)?.isVisible =
+                            app.exodusVersionCode != app.versionCode
+                    }
                     setOnMenuItemClickListener {
                         when (it.itemId) {
                             R.id.openExodusPage -> {
                                 customTabsIntent.launchUrl(
                                     view.context,
-                                    Uri.parse(exodusReportPage + app.report)
+                                    Uri.parse(exodusReportPage + app.report),
                                 )
                             }
                             R.id.submitApp -> {
                                 customTabsIntent.launchUrl(
                                     view.context,
-                                    Uri.parse(exodusSubmitPage + app.packageName)
+                                    Uri.parse(exodusSubmitPage + app.packageName),
                                 )
                             }
                             R.id.openStore -> {
                                 try {
                                     customTabsIntent.launchUrl(
                                         view.context,
-                                        Uri.parse(storePage + app.packageName)
+                                        Uri.parse(storePage + app.packageName),
                                     )
                                 } catch (e: ActivityNotFoundException) {
                                     customTabsIntent.launchUrl(
                                         view.context,
-                                        Uri.parse(GPPage + app.packageName)
+                                        Uri.parse(GPPage + app.packageName),
                                     )
                                 }
                             }
@@ -151,15 +154,15 @@ class AppDetailFragment : Fragment(R.layout.fragment_app_detail) {
                     if (dateCreated != dateUpdated) {
                         appReportTV.text = getString(
                             R.string.report_date,
-                            dateCreated
+                            dateCreated,
                         ) + " " + getString(
                             R.string.updated,
-                            dateUpdated
+                            dateUpdated,
                         )
                     } else {
                         appReportTV.text = getString(
                             R.string.report_date,
-                            dateCreated
+                            dateCreated,
                         )
                     }
                 } else {
@@ -199,7 +202,7 @@ class AppDetailFragment : Fragment(R.layout.fragment_app_detail) {
                                 contentDescription = getString(R.string.permissions)
                                 icon = ContextCompat.getDrawable(
                                     view.context,
-                                    R.drawable.ic_permission
+                                    R.drawable.ic_permission,
                                 )
                             }
                         }

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/AppDetailViewModel.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/AppDetailViewModel.kt
@@ -16,7 +16,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class AppDetailViewModel @Inject constructor(
-    private val exodusDatabaseRepository: ExodusDatabaseRepository
+    private val exodusDatabaseRepository: ExodusDatabaseRepository,
 ) : ViewModel() {
 
     val app: MutableLiveData<ExodusApplication> = MutableLiveData()

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/model/ADPermissionsRVAdapter.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/model/ADPermissionsRVAdapter.kt
@@ -18,8 +18,8 @@ class ADPermissionsRVAdapter :
             RecyclerViewPermissionItemBinding.inflate(
                 LayoutInflater.from(parent.context),
                 parent,
-                false
-            )
+                false,
+            ),
         )
     }
 

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/subfrags/ADPermissionsFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/subfrags/ADPermissionsFragment.kt
@@ -64,7 +64,7 @@ class ADPermissionsFragment : Fragment(R.layout.fragment_a_d_permissions) {
                     setOnClickListener {
                         customTabsIntent.launchUrl(
                             view.context,
-                            Uri.parse(googleInfoPage)
+                            Uri.parse(googleInfoPage),
                         )
                     }
                 }
@@ -73,7 +73,7 @@ class ADPermissionsFragment : Fragment(R.layout.fragment_a_d_permissions) {
                     setOnClickListener {
                         customTabsIntent.launchUrl(
                             view.context,
-                            Uri.parse(permissionsInfoPage)
+                            Uri.parse(permissionsInfoPage),
                         )
                     }
                 }

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/subfrags/ADTrackersFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/subfrags/ADTrackersFragment.kt
@@ -57,7 +57,7 @@ class ADTrackersFragment : Fragment(R.layout.fragment_a_d_trackers) {
                     setOnClickListener {
                         customTabsIntent.launchUrl(
                             view.context,
-                            Uri.parse(trackersInfoPage)
+                            Uri.parse(trackersInfoPage),
                         )
                     }
                 }

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/apps/AppsFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/apps/AppsFragment.kt
@@ -86,7 +86,7 @@ class AppsFragment : Fragment(R.layout.fragment_apps) {
                             updateReportsFab.show()
                         }
                     }
-                }
+                },
             )
         }
 

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/apps/AppsViewModel.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/apps/AppsViewModel.kt
@@ -9,7 +9,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class AppsViewModel @Inject constructor(
-    exodusDatabaseRepository: ExodusDatabaseRepository
+    exodusDatabaseRepository: ExodusDatabaseRepository,
 ) : ViewModel() {
 
     val appList: LiveData<List<ExodusApplication>> = exodusDatabaseRepository.getAllApps()

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/apps/model/AppsDiffUtil.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/apps/model/AppsDiffUtil.kt
@@ -11,7 +11,7 @@ class AppsDiffUtil : DiffUtil.ItemCallback<ExodusApplication>() {
 
     override fun areContentsTheSame(
         oldItem: ExodusApplication,
-        newItem: ExodusApplication
+        newItem: ExodusApplication,
     ): Boolean {
         return when {
             oldItem.icon != newItem.icon -> false

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/apps/model/AppsRVAdapter.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/apps/model/AppsRVAdapter.kt
@@ -16,7 +16,7 @@ import org.eu.exodus_privacy.exodusprivacy.utils.safeNavigate
 import org.eu.exodus_privacy.exodusprivacy.utils.setExodusColor
 
 class AppsRVAdapter(
-    private val currentDestinationId: Int
+    private val currentDestinationId: Int,
 ) : ListAdapter<ExodusApplication, AppsRVAdapter.ViewHolder>(AppsDiffUtil()) {
 
     inner class ViewHolder(val binding: RecyclerViewAppItemBinding) :
@@ -27,8 +27,8 @@ class AppsRVAdapter(
             RecyclerViewAppItemBinding.inflate(
                 LayoutInflater.from(parent.context),
                 parent,
-                false
-            )
+                false,
+            ),
         )
     }
 
@@ -43,7 +43,7 @@ class AppsRVAdapter(
                         AppsFragmentDirections.actionAppsFragmentToAppDetailFragment(app.packageName)
                     } else {
                         TrackerDetailFragmentDirections.actionTrackerDetailFragmentToAppDetailFragment(
-                            app.packageName
+                            app.packageName,
                         )
                     }
                     it.findNavController().safeNavigate(action)

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/dialog/ExodusDialogFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/dialog/ExodusDialogFragment.kt
@@ -41,8 +41,8 @@ class ExodusDialogFragment : DialogFragment() {
             .setMessage(
                 HtmlCompat.fromHtml(
                     getString(R.string.warning_desc),
-                    HtmlCompat.FROM_HTML_MODE_COMPACT
-                )
+                    HtmlCompat.FROM_HTML_MODE_COMPACT,
+                ),
             ).setPositiveButton(getString(R.string.accept)) { _, _ ->
                 Log.d(TAG, "Permission to transmit data granted!")
                 exodusDialogViewModel.savePolicyAgreement(true)
@@ -60,7 +60,7 @@ class ExodusDialogFragment : DialogFragment() {
     }
 
     private val requestPermissionLauncher = registerForActivityResult(
-        ActivityResultContracts.RequestPermission()
+        ActivityResultContracts.RequestPermission(),
     ) { _: Boolean ->
         exodusDialogViewModel.saveNotificationPermissionRequested(true)
     }
@@ -68,7 +68,7 @@ class ExodusDialogFragment : DialogFragment() {
     private fun isNotificationPermissionGranted(): Boolean {
         return ContextCompat.checkSelfPermission(
             requireContext(),
-            permission
+            permission,
         ) == PackageManager.PERMISSION_GRANTED
     }
 

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/dialog/ThemeDialogFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/dialog/ThemeDialogFragment.kt
@@ -15,9 +15,9 @@ class ThemeDialogFragment : DialogFragment() {
                 arrayOf(
                     getString(R.string.dark_theme),
                     getString(R.string.light_theme),
-                    getString(R.string.system_theme)
+                    getString(R.string.system_theme),
                 ),
-                2
+                2,
             ) { _, _ ->
                 this.dismiss()
             }

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/trackerdetail/TrackerDetailFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/trackerdetail/TrackerDetailFragment.kt
@@ -64,7 +64,7 @@ class TrackerDetailFragment : Fragment(R.layout.fragment_tracker_detail) {
                         if (it.itemId == R.id.openTrackerPage) {
                             customTabsIntent.launchUrl(
                                 view.context,
-                                Uri.parse(tracker.website)
+                                Uri.parse(tracker.website),
                             )
                         }
                         true
@@ -80,7 +80,7 @@ class TrackerDetailFragment : Fragment(R.layout.fragment_tracker_detail) {
                         view.context,
                         null,
                         0,
-                        R.style.Theme_Exodus_Chip
+                        R.style.Theme_Exodus_Chip,
                     )
                     chip.text = it
                     chip.setChipDrawable(chipStyle)
@@ -94,7 +94,7 @@ class TrackerDetailFragment : Fragment(R.layout.fragment_tracker_detail) {
                         R.plurals.trackers_presence,
                         tracker.exodusApplications.size,
                         args.percentage,
-                        tracker.exodusApplications.size
+                        tracker.exodusApplications.size,
                     )
                 }
 

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/trackerdetail/TrackerDetailViewModel.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/trackerdetail/TrackerDetailViewModel.kt
@@ -12,7 +12,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class TrackerDetailViewModel @Inject constructor(
-    private val exodusDatabaseRepository: ExodusDatabaseRepository
+    private val exodusDatabaseRepository: ExodusDatabaseRepository,
 ) : ViewModel() {
 
     val tracker: MutableLiveData<TrackerData> = MutableLiveData()

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/trackers/TrackersViewModel.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/trackers/TrackersViewModel.kt
@@ -9,7 +9,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class TrackersViewModel @Inject constructor(
-    exodusDatabaseRepository: ExodusDatabaseRepository
+    exodusDatabaseRepository: ExodusDatabaseRepository,
 ) : ViewModel() {
 
     val trackersList: LiveData<List<TrackerData>> = exodusDatabaseRepository.getAllTrackers()

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/trackers/model/TrackersRVAdapter.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/trackers/model/TrackersRVAdapter.kt
@@ -24,7 +24,7 @@ import org.eu.exodus_privacy.exodusprivacy.utils.safeNavigate
 
 class TrackersRVAdapter(
     private val showSuggestions: Boolean,
-    private val currentDestinationId: Int
+    private val currentDestinationId: Int,
 ) :
     ListAdapter<TrackerData, TrackersRVAdapter.ViewHolder>(TrackersDiffUtil()) {
 
@@ -38,8 +38,8 @@ class TrackersRVAdapter(
             RecyclerViewTrackerItemBinding.inflate(
                 LayoutInflater.from(parent.context),
                 parent,
-                false
-            )
+                false,
+            ),
         )
     }
 
@@ -51,7 +51,7 @@ class TrackersRVAdapter(
 
         Log.d(
             TAG,
-            "ApplicationsList in TrackerData: ${app.exodusApplications}. " + "Size: ${app.exodusApplications.size}."
+            "ApplicationsList in TrackerData: ${app.exodusApplications}. " + "Size: ${app.exodusApplications.size}.",
         )
 
         val trackerPercentage =
@@ -65,7 +65,7 @@ class TrackersRVAdapter(
         if (!showSuggestions) {
             val params = RelativeLayout.LayoutParams(
                 RelativeLayout.LayoutParams.MATCH_PARENT,
-                RelativeLayout.LayoutParams.WRAP_CONTENT
+                RelativeLayout.LayoutParams.WRAP_CONTENT,
             )
             val horMargin = convertPXToDP(20, context).toInt()
             val verMargin = convertPXToDP(10, context).toInt()
@@ -85,7 +85,7 @@ class TrackersRVAdapter(
                         context,
                         null,
                         0,
-                        R.style.Theme_Exodus_Chip
+                        R.style.Theme_Exodus_Chip,
                     )
                     chip.text = it
                     chip.setChipDrawable(chipStyle)
@@ -97,7 +97,7 @@ class TrackersRVAdapter(
                         R.plurals.trackers_status,
                         app.exodusApplications.size,
                         trackerPercentage.toInt(),
-                        app.exodusApplications.size
+                        app.exodusApplications.size,
                     )
                 trackersPB.apply {
                     val newWidth = (getDisplayWidth(context) * trackerPercentage) / 100
@@ -113,12 +113,12 @@ class TrackersRVAdapter(
                         if (currentDestinationId == R.id.appDetailFragment) {
                             AppDetailFragmentDirections.actionAppDetailFragmentToTrackerDetailFragment(
                                 app.id,
-                                trackerPercentage.toInt()
+                                trackerPercentage.toInt(),
                             )
                         } else {
                             TrackersFragmentDirections.actionTrackersFragmentToTrackerDetailFragment(
                                 app.id,
-                                trackerPercentage.toInt()
+                                trackerPercentage.toInt(),
                             )
                         }
                     holder.itemView.findNavController().safeNavigate(action)
@@ -131,7 +131,7 @@ class TrackersRVAdapter(
         return TypedValue.applyDimension(
             TypedValue.COMPLEX_UNIT_DIP,
             pixels.toFloat(),
-            context.resources.displayMetrics
+            context.resources.displayMetrics,
         )
     }
 

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/database/ExodusDatabase.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/database/ExodusDatabase.kt
@@ -18,8 +18,8 @@ import org.eu.exodus_privacy.exodusprivacy.objects.Constants
         AutoMigration(
             from = Constants.previousDatabaseVersion,
             to = Constants.currentDatabaseVersion,
-        )
-    ]
+        ),
+    ],
 )
 @TypeConverters(ExodusDatabaseConverters::class)
 abstract class ExodusDatabase : RoomDatabase() {

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/database/ExodusDatabaseRepository.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/database/ExodusDatabaseRepository.kt
@@ -11,7 +11,7 @@ import javax.inject.Inject
 
 class ExodusDatabaseRepository @Inject constructor(
     exodusDatabase: ExodusDatabase,
-    @IoDispatcher val ioDispatcher: CoroutineDispatcher
+    @IoDispatcher val ioDispatcher: CoroutineDispatcher,
 ) {
 
     private val trackerDataDao = exodusDatabase.trackerDataDao()
@@ -73,7 +73,7 @@ class ExodusDatabaseRepository @Inject constructor(
             } else {
                 Log.d(
                     TAG,
-                    "Failed to get ExodusApplication from DB returning empty ExodusApplication()."
+                    "Failed to get ExodusApplication from DB returning empty ExodusApplication().",
                 )
                 ExodusApplication()
             }

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/database/app/ExodusApplication.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/database/app/ExodusApplication.kt
@@ -20,5 +20,5 @@ data class ExodusApplication(
     val source: Source = Source.GOOGLE,
     val report: Int = 0,
     val created: String = String(),
-    val updated: String = String()
+    val updated: String = String(),
 )

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/database/tracker/TrackerData.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/database/tracker/TrackerData.kt
@@ -16,5 +16,5 @@ data class TrackerData(
     val website: String = String(),
     var presentOnDevice: Boolean = false,
     val exodusApplications: MutableList<String> = mutableListOf(),
-    @ColumnInfo(defaultValue = 0.toString()) var totalNumberOfAppsHavingTrackers: Int = 0
+    @ColumnInfo(defaultValue = 0.toString()) var totalNumberOfAppsHavingTrackers: Int = 0,
 )

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/network/ExodusAPIInterface.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/network/ExodusAPIInterface.kt
@@ -17,6 +17,6 @@ interface ExodusAPIInterface {
 
     @GET("search/{packageName}/details")
     suspend fun getAppDetails(
-        @Path("packageName") packageName: String
+        @Path("packageName") packageName: String,
     ): Response<List<AppDetails>>
 }

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/network/ExodusAPIRepository.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/network/ExodusAPIRepository.kt
@@ -11,7 +11,7 @@ import javax.inject.Inject
 class ExodusAPIRepository @Inject constructor(
     private val exodusAPIInterface: ExodusAPIInterface,
     private val networkManager: NetworkManager,
-    @IoDispatcher val ioDispatcher: CoroutineDispatcher
+    @IoDispatcher val ioDispatcher: CoroutineDispatcher,
 ) {
     private val TAG = ExodusAPIRepository::class.java.simpleName
 
@@ -26,7 +26,7 @@ class ExodusAPIRepository @Inject constructor(
                 } else {
                     Log.w(
                         TAG,
-                        "Failed to get trackers, response code: ${result.code()}. Returning empty Trackers object."
+                        "Failed to get trackers, response code: ${result.code()}. Returning empty Trackers object.",
                     )
                     Trackers()
                 }
@@ -48,7 +48,7 @@ class ExodusAPIRepository @Inject constructor(
                 } else {
                     Log.w(
                         TAG,
-                        "Failed to get app details, response code: ${result.code()}. Returning emptyList."
+                        "Failed to get app details, response code: ${result.code()}. Returning emptyList.",
                     )
                     emptyList()
                 }

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/network/NetworkManager.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/network/NetworkManager.kt
@@ -18,7 +18,7 @@ import javax.inject.Singleton
 
 @Singleton
 class NetworkManager @Inject constructor(
-    @ApplicationContext private val context: Context
+    @ApplicationContext private val context: Context,
 ) {
     private val TAG = NetworkManager::class.java.simpleName
 
@@ -31,7 +31,7 @@ class NetworkManager @Inject constructor(
     init {
         ContextCompat.getSystemService(
             context,
-            ConnectivityManager::class.java
+            ConnectivityManager::class.java,
         )?.registerNetworkCallback(
             NetworkRequest.Builder()
                 .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
@@ -50,7 +50,7 @@ class NetworkManager @Inject constructor(
                     _networkState.value = false
                     postNetworkStateValue()
                 }
-            }
+            },
         )
     }
 

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/network/data/AppDetails.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/network/data/AppDetails.kt
@@ -15,5 +15,5 @@ data class AppDetails(
     val uaid: String = String(),
     val updated: String = String(),
     val version_code: String = String(),
-    val version_name: String = String()
+    val version_name: String = String(),
 )

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/network/data/Tracker.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/network/data/Tracker.kt
@@ -7,5 +7,5 @@ data class Tracker(
     val description: String = String(),
     val name: String = String(),
     val network_signature: String = String(),
-    val website: String = String()
+    val website: String = String(),
 )

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/network/data/Trackers.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/network/data/Trackers.kt
@@ -1,5 +1,5 @@
 package org.eu.exodus_privacy.exodusprivacy.manager.network.data
 
 data class Trackers(
-    val trackers: Map<String, Tracker> = emptyMap()
+    val trackers: Map<String, Tracker> = emptyMap(),
 )

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/packageinfo/ExodusPackageRepository.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/packageinfo/ExodusPackageRepository.kt
@@ -19,7 +19,7 @@ import javax.inject.Inject
 
 class ExodusPackageRepository @Inject constructor(
     private val packageManager: PackageManager,
-    @IoDispatcher val ioDispatcher: CoroutineDispatcher
+    @IoDispatcher val ioDispatcher: CoroutineDispatcher,
 ) {
     private val TAG = ExodusPackageRepository::class.java.simpleName
     private val GOOGLE_PLAY_STORE = "com.android.vending"
@@ -29,7 +29,7 @@ class ExodusPackageRepository @Inject constructor(
     private val resolution = 96
 
     suspend fun getApplicationList(
-        validPackages: List<PackageInfo>
+        validPackages: List<PackageInfo>,
     ): MutableList<Application> {
         val permissionsMap = generatePermissionsMap(validPackages, packageManager)
         val applicationList = mutableListOf<Application>()
@@ -43,7 +43,7 @@ class ExodusPackageRepository @Inject constructor(
                 packageInfo.versionName ?: "",
                 PackageInfoCompat.getLongVersionCode(packageInfo),
                 permissionsMap[packageInfo.packageName] ?: emptyList(),
-                getAppStore(packageInfo.packageName, packageManager)
+                getAppStore(packageInfo.packageName, packageManager),
             )
             Log.d(TAG, "Add app: ${app.name}, ${app.versionName}")
             applicationList.add(app)
@@ -65,13 +65,13 @@ class ExodusPackageRepository @Inject constructor(
 
     suspend fun generatePermissionsMap(
         packages: List<PackageInfo>,
-        packageManager: PackageManager
+        packageManager: PackageManager,
     ): MutableMap<String, List<Permission>> {
         return withContext(ioDispatcher) {
             val packagesWithPermissions = packages.filterNot { it.requestedPermissions == null }
             Log.d(TAG, "Packages with perms: $packagesWithPermissions")
             val permissionInfoSet = packagesWithPermissions.fold(
-                hashSetOf<String>()
+                hashSetOf<String>(),
             ) { acc, next ->
                 if (next.requestedPermissions != null) {
                     acc.addAll(next.requestedPermissions)
@@ -86,7 +86,7 @@ class ExodusPackageRepository @Inject constructor(
             permissionList = permissionList.sortedWith(
                 compareBy(String.CASE_INSENSITIVE_ORDER) {
                     it.shortName
-                }
+                },
             )
             Log.d(TAG, "Permission List: $permissionList")
             packagesWithPermissions.forEach { packageInfo ->
@@ -105,7 +105,7 @@ class ExodusPackageRepository @Inject constructor(
         try {
             permInfo = packageManager.getPermissionInfo(
                 longName,
-                PackageManager.GET_META_DATA
+                PackageManager.GET_META_DATA,
             )
         } catch (exception: PackageManager.NameNotFoundException) {
             Log.d(TAG, "Unable to find info about $longName.")
@@ -118,13 +118,13 @@ class ExodusPackageRepository @Inject constructor(
             return Permission(
                 shortName,
                 longName,
-                label.toString()
+                label.toString(),
             )
         } ?: run {
             return Permission(
                 shortName,
                 longName,
-                longName
+                longName,
             )
         }
     }

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/storage/ExodusDataStoreRepository.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/manager/storage/ExodusDataStoreRepository.kt
@@ -23,7 +23,7 @@ class ExodusDataStoreRepository<ExodusConfig> @Inject constructor(
     private val preferenceKey: Preferences.Key<String>,
     private val typeToken: TypeToken<Map<String, ExodusConfig>>,
     name: DataStoreName,
-    @ApplicationContext val context: Context
+    @ApplicationContext val context: Context,
 ) : ExodusStorage<ExodusConfig> {
 
     private val Context.dataStore by preferencesDataStore(name.name)
@@ -33,8 +33,8 @@ class ExodusDataStoreRepository<ExodusConfig> @Inject constructor(
         return gson.toJson(
             mapOf(
                 "privacy_policy" to ExodusConfig("privacy_policy_consent", false),
-                "notification_perm" to ExodusConfig("notification_requested", false)
-            )
+                "notification_perm" to ExodusConfig("notification_requested", false),
+            ),
         )
     }
 

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/objects/Application.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/objects/Application.kt
@@ -9,5 +9,5 @@ data class Application(
     val versionName: String = String(),
     val versionCode: Long = 0L,
     val permissions: List<Permission> = emptyList(),
-    val source: Source = Source.SYSTEM
+    val source: Source = Source.SYSTEM,
 )

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/objects/Permission.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/objects/Permission.kt
@@ -3,5 +3,5 @@ package org.eu.exodus_privacy.exodusprivacy.objects
 data class Permission(
     val shortName: String = String(),
     val longName: String = String(),
-    val label: String = String()
+    val label: String = String(),
 )

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/objects/Source.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/objects/Source.kt
@@ -4,5 +4,5 @@ enum class Source {
     GOOGLE,
     FDROID,
     USER,
-    SYSTEM
+    SYSTEM,
 }

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/CommonExtensions.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/CommonExtensions.kt
@@ -37,8 +37,8 @@ fun Chip.setExodusColor(size: Int) {
             ColorStateList.valueOf(
                 ContextCompat.getColor(
                     context,
-                    com.google.android.material.R.color.m3_chip_text_color
-                )
+                    com.google.android.material.R.color.m3_chip_text_color,
+                ),
             )
         this.chipIconTint = colorForeground
         this.setTextColor(colorForeground)

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/NotificationManagerModule.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/NotificationManagerModule.kt
@@ -23,7 +23,7 @@ object NotificationManagerModule {
     @Singleton
     @Provides
     fun provideNotificationManagerInstance(
-        @ApplicationContext context: Context
+        @ApplicationContext context: Context,
     ): NotificationManagerCompat {
         return NotificationManagerCompat.from(context)
     }
@@ -32,7 +32,7 @@ object NotificationManagerModule {
     @Provides
     @RequiresApi(Build.VERSION_CODES.O)
     fun provideUpdateNotificationChannel(
-        @ApplicationContext context: Context
+        @ApplicationContext context: Context,
     ): NotificationChannelCompat {
         return NotificationChannelCompat
             .Builder(UPDATES, NotificationManagerCompat.IMPORTANCE_LOW)
@@ -42,7 +42,7 @@ object NotificationManagerModule {
 
     @Provides
     fun provideUpdateNotification(
-        @ApplicationContext context: Context
+        @ApplicationContext context: Context,
     ): NotificationCompat.Builder {
         return NotificationCompat.Builder(context, UPDATES)
             .setSmallIcon(R.drawable.ic_update)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 androidGradlePlugin = "8.1.4"
 kotlinPlugin = "1.9.22"
-gradleKtlint = "11.1.0"
+gradleKtlint = "12.0.3"
 activity-ktx = "1.8.1"
 androidx-core = "1.5.0"
 appcompat = "1.6.1"


### PR DESCRIPTION
Closes #365
Closes #300 

- Add new config linter and disable rules about package name
- Fix errors generate by linter

disabledRules is depreciated on most recent of linter, but for now new method (use .editorconfig)is not support by the gradle plugin ktlint