### PR TITLE
Fix deprecations

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,7 +76,7 @@ android {
             isIncludeAndroidResources = true
         }
     }
-    packagingOptions {
+    packaging {
         resources.excludes.add("META-INF/*")
     }
     sourceSets {


### PR DESCRIPTION
This PR fixes deprecation in gradle script.
We use packagingOptions to exclude license files libraries in APK.
In latest version of Gradle, this feature have been replaced by packaging.
More information here https://stackoverflow.com/questions/75172062/how-to-replace-deprecated-packagingoptions-in-android-gradle-build-files