### PR TITLE
Add ability to copy network signature

### DIFF
--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/trackerdetail/TrackerDetailFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/trackerdetail/TrackerDetailFragment.kt
@@ -20,6 +20,7 @@ import io.noties.markwon.Markwon
 import org.eu.exodus_privacy.exodusprivacy.R
 import org.eu.exodus_privacy.exodusprivacy.databinding.FragmentTrackerDetailBinding
 import org.eu.exodus_privacy.exodusprivacy.fragments.apps.model.AppsRVAdapter
+import org.eu.exodus_privacy.exodusprivacy.utils.copyToClipboard
 import org.eu.exodus_privacy.exodusprivacy.utils.openURL
 import javax.inject.Inject
 
@@ -116,6 +117,12 @@ class TrackerDetailFragment : Fragment(R.layout.fragment_tracker_detail) {
                 codeSignTV.text = tracker.code_signature
                 if (tracker.network_signature.isNotEmpty()) {
                     networkSignTV.text = tracker.network_signature
+                    networkSignTV.setOnLongClickListener {
+                        copyToClipboard(
+                            requireContext(),
+                            networkSignTV.text.toString(),
+                        )
+                    }
                     networkDetectTV.visibility = View.VISIBLE
                     networkSignTV.visibility = View.VISIBLE
                 } else {

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/CommonExtensions.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/CommonExtensions.kt
@@ -1,9 +1,13 @@
 package org.eu.exodus_privacy.exodusprivacy.utils
 
+import android.content.ClipData.newPlainText
+import android.content.ClipboardManager
+import android.content.Context
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.content.res.ColorStateList
 import android.os.Build
+import android.widget.Toast
 import androidx.core.content.ContextCompat
 import com.google.android.material.chip.Chip
 import org.eu.exodus_privacy.exodusprivacy.R
@@ -67,4 +71,13 @@ fun PackageManager.getSource(packageName: String): String? {
         @Suppress("DEPRECATION")
         this.getInstallerPackageName(packageName)
     }
+}
+
+fun copyToClipboard(context: Context, string: String): Boolean {
+    val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    clipboardManager.setPrimaryClip(newPlainText("", string))
+    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+        Toast.makeText(context, "Copied", Toast.LENGTH_SHORT).show()
+    }
+    return true
 }


### PR DESCRIPTION
This PR implements a new util method to copy content in the clipboard, this new method is used in tracker detail fragment to add the ability to copy network signatures (with long press) in clipboard to use in ad blocker app
Fixes #89
https://github.com/Exodus-Privacy/exodus-android-app/assets/87148630/340d0608-c24e-4fcf-8dbf-7f22bea4590a
