### PR TITLE
Bump upload artifact actions to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           args: /github/workspace/app/build/outputs/apk/debug/app-debug.apk
       - name: Upload APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: app_debug
           path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           args: /github/workspace/app/build/outputs/apk/release/app-release.apk
       - name: Upload APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: app_release
           path: app/build/outputs/apk/release/app-release.apk


### PR DESCRIPTION
With this new version, the size of artifact visible in checks takes now size of archive instead take a size of elements inside archive