### PR TITLE
Move build config property

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -85,6 +85,7 @@ android {
     }
     buildFeatures {
         viewBinding = true
+        buildConfig = true
     }
     lint {
         lintConfig = file("lint.xml")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,8 +24,7 @@ android {
         versionCode = 17
         versionName = "3.2.0"
         testInstrumentationRunner = "org.eu.exodus_privacy.exodusprivacy.ExodusTestRunner"
-        val API_KEY = System.getenv("EXODUS_API_KEY")
-        buildConfigField("String", "EXODUS_API_KEY", "\"$API_KEY\"")
+        buildConfigField("String", "EXODUS_API_KEY", "\"${System.getenv("EXODUS_API_KEY")}\"")
 
         ksp {
             arg(

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,6 @@ android.useAndroidX=true
 android.enableJetifier=false
 android.nonTransitiveRClass=true
 android.enableR8.fullMode=false
-android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false
 
 kotlin.code.style=official


### PR DESCRIPTION
buildConfig in gradle.properties is deprecated in latest version of gradle (8.4), we need to specify property in each module of the project -> https://stackoverflow.com/questions/74634321/fixing-the-build-type-contains-custom-buildconfig-fields-but-the-feature-is-di

I have also removed unused value -> I have check that doesn't break Fdroid build