### PR TITLE
Use latest version of ktlint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,4 +3,14 @@
 root = true
 
 [*.{kt,kts}]
+ktlint_standard_annotation = disabled
+ktlint_standard_blank-line-before-declaration = disabled
+ktlint_standard_function-signature = disabled
+ktlint_standard_indent = disabled
+ktlint_standard_max-line-length = disabled
+ktlint_standard_multiline-expression-wrapping = disabled
+ktlint_standard_no-empty-first-line-in-class-body = disabled
 ktlint_standard_package-name = disabled
+ktlint_standard_parameter-list-wrapping = disabled
+ktlint_standard_property-naming = disabled
+ktlint_standard_string-template-indent = disabled

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
-    version.set("0.50.0")
+    version.set("1.1.1")
     android.set(true)
 }
 


### PR DESCRIPTION
This PR updates linter to the latest version (1.1.1), this version doing break changes that's why I have disabled rules to do not need to reformat all files and pollutes git blame.
List of rules:
https://pinterest.github.io/ktlint/latest/rules/experimental/