### PR TITLE
change mastodon url to direct framapiaf.org link

### DIFF
--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/about/AboutFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/about/AboutFragment.kt
@@ -36,7 +36,7 @@ class AboutFragment : PreferenceFragmentCompat() {
         private const val privacyPolicyURL = "https://exodus-privacy.eu.org/en/page/privacy-policy/"
         private const val sourceCodeURL = "https://github.com/Exodus-Privacy/exodus-android-app"
         private const val websiteURL = "https://exodus-privacy.eu.org/"
-        private const val mastodonURL = "https://mastodon.social/@exodus@framapiaf.org"
+        private const val mastodonURL = "https://framapiaf.org/@exodus"
         private const val emailID = "contact@exodus-privacy.eu.org"
     }
 


### PR DESCRIPTION
This avoids the unnecessary redirect via mastodon.social and this ugly screen:

![Screenshot_20240205_204510](https://github.com/Exodus-Privacy/exodus-android-app/assets/10157047/e72d2d37-34db-40c3-a2e4-315b637f1ce6)
