### PR TITLE
fix building on Windows with spaces in path

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,9 +28,7 @@ android {
         buildConfigField("String", "EXODUS_API_KEY", "\"$API_KEY\"")
 
         ksp {
-            arg(
-                RoomSchemaArgProvider(File(projectDir, "schemas")),
-            )
+            arg("room.schemaLocation", "$projectDir/schemas")
         }
 
         signingConfigs {


### PR DESCRIPTION
Without this the build fails with `KSP apoption does not match \S+=\S+: room.schemaLocation=C:\Users\Conny Duck\AndroidApps\exodus-android-app\app\schemas`