### PR TITLE
Remove pressed color when you switch between tabs in app detail fragment

### DIFF
--- a/app/src/main/res/layout/fragment_app_detail.xml
+++ b/app/src/main/res/layout/fragment_app_detail.xml
@@ -210,15 +210,16 @@
                     tools:text="Report created on April 26, 2022" />
 
                 <com.google.android.material.tabs.TabLayout
-                    android:id="@+id/tabLayout"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="12dp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/appReportTV"
-                    app:tabIndicatorFullWidth="true"
-                    app:tabInlineLabel="true" />
+                  android:id="@+id/tabLayout"
+                  android:layout_width="match_parent"
+                  android:layout_height="wrap_content"
+                  android:layout_marginTop="12dp"
+                  app:layout_constraintEnd_toEndOf="parent"
+                  app:layout_constraintStart_toStartOf="parent"
+                  app:layout_constraintTop_toBottomOf="@id/appReportTV"
+                  app:tabIndicatorFullWidth="true"
+                  app:tabInlineLabel="true"
+                  app:tabRippleColor="@android:color/transparent" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
I have replaced purple color by transparent color when user select a tab to switch to permissions tab or trackers tab.
|Before|After|
|-|-|
|<img src="https://github.com/Exodus-Privacy/exodus-android-app/assets/87148630/f643252b-cb6e-4a7b-8dea-e02b31e60f2f" height=500 />|<img src="https://github.com/Exodus-Privacy/exodus-android-app/assets/87148630/8e88308f-41b6-431d-a2b3-170aeb2d2e61" height=500 />
