### PR TITLE
Fix tracker detail fragment layout

### DIFF
--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/trackerdetail/TrackerDetailFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/trackerdetail/TrackerDetailFragment.kt
@@ -150,11 +150,7 @@ class TrackerDetailFragment : Fragment(R.layout.fragment_tracker_detail) {
                         } else {
                             1
                         }
-                    layoutManager = object : StaggeredGridLayoutManager(column, 1) {
-                        override fun canScrollVertically(): Boolean {
-                            return false
-                        }
-                    }
+                    layoutManager = StaggeredGridLayoutManager(column, 1)
                 }
                 appsRVAdapter.submitList(it)
             }

--- a/app/src/main/res/layout/fragment_tracker_detail.xml
+++ b/app/src/main/res/layout/fragment_tracker_detail.xml
@@ -187,15 +187,16 @@
 
       </androidx.constraintlayout.widget.ConstraintLayout>
     </com.google.android.material.appbar.CollapsingToolbarLayout>
-    
-    <androidx.recyclerview.widget.RecyclerView
-      android:id="@+id/appsListRV"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="5dp"
-      android:visibility="gone"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/appsListTV" />
   </com.google.android.material.appbar.AppBarLayout>
+  <androidx.recyclerview.widget.RecyclerView
+    android:id="@+id/appsListRV"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_gravity="center"
+    android:layout_marginTop="5dp"
+    android:layout_marginStart="5dp"
+    android:layout_marginEnd="5dp"
+    android:scrollbars="none"
+    android:visibility="gone"
+    app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"/>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
This PR fixes:
- Scrolling not working properly -> introduced by #398
- Fix number of apps present in the list -> introduced by #309 (In latest version, we can see at the maximum, 8 apps in list)

Before

https://github.com/Exodus-Privacy/exodus-android-app/assets/87148630/42f29c01-7f9a-469a-bfda-f047caf4e7ad

After

https://github.com/Exodus-Privacy/exodus-android-app/assets/87148630/39520b11-cf0a-463f-9a54-4b5833a5dc72