### PR TITLE
Bump ktlint to 1.2.1 version

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,4 +13,5 @@ ktlint_standard_no-empty-first-line-in-class-body = disabled
 ktlint_standard_package-name = disabled
 ktlint_standard_parameter-list-wrapping = disabled
 ktlint_standard_property-naming = disabled
+ktlint_standard_backing-property-naming = disabled
 ktlint_standard_string-template-indent = disabled

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
-    version.set("1.1.1")
+    version.set("1.2.1")
     android.set(true)
 }
 


### PR DESCRIPTION
https://github.com/pinterest/ktlint/releases/tag/1.2.1

I have disabled backing-property-naming rule to allow to name variables with an underscore as the first character -> Google uses this syntax in the documentation
https://pinterest.github.io/ktlint/latest/rules/standard/#property-naming