### PR TITLE
Fixed spelling error

### DIFF
--- a/app/src/main/res/layout/recycler_view_app_item.xml
+++ b/app/src/main/res/layout/recycler_view_app_item.xml
@@ -51,7 +51,7 @@
     app:layout_constraintHorizontal_bias="1"
     app:layout_constraintStart_toEndOf="@id/appIconIV"
     app:layout_constraintTop_toBottomOf="@id/appNameTV"
-    tools:text="Analyzed version is different that installed version" />
+    tools:text="Analyzed version is different than installed version" />
   <com.google.android.material.chip.Chip
     android:id="@+id/trackersChip"
     style="@style/Theme.Exodus.Chip"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="permissions">Permissions</string>
     <string name="not_connected">No Internet Connection</string>
     <string name="settings">Settings</string>
-    <string name="version_mismatch">Analyzed version is different that installed version.</string>
+    <string name="version_mismatch">Analyzed version is different than installed version.</string>
     <string name="version_unavailable">This app hasn\'t been analysed by Exodus Privacy yet.</string>
     <string name="no_app_found">It appears that you don\'t have any apps installed from the source we test (Google Play store or F-Droid).</string>
     <string name="no_settings">This app doesn\'t have settings</string>


### PR DESCRIPTION
'Than' is spelled as 'that':

![Screenshot_20240414_001754_Exodus](https://github.com/Exodus-Privacy/exodus-android-app/assets/87303800/40588a9a-b992-44f4-b7ad-31833f56b319)
