### PR TITLE
Add text about restrictions

### DIFF
--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/model/ADStatusRVAdapter.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/model/ADStatusRVAdapter.kt
@@ -1,6 +1,7 @@
 package org.eu.exodus_privacy.exodusprivacy.fragments.appdetail.model
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import org.eu.exodus_privacy.exodusprivacy.R
@@ -51,7 +52,9 @@ class ADStatusRVAdapter(
                 labelTV.setText(R.string.trackers)
                 if (app.exodusVersionCode == 0L) {
                     statusTV.setText(R.string.analyzed)
+                    restrictionTV.visibility = View.VISIBLE
                 } else if (app.exodusTrackers.isEmpty()) {
+                    restrictionTV.visibility = View.GONE
                     statusTV.setText(R.string.code_signature_not_found)
                 } else {
                     statusTV.setText(R.string.code_signature_found)

--- a/app/src/main/res/layout/recycler_view_ad_status_item.xml
+++ b/app/src/main/res/layout/recycler_view_ad_status_item.xml
@@ -46,4 +46,14 @@
         app:layout_constraintTop_toBottomOf="@id/countChip"
         tools:text="@string/code_permission_not_found" />
 
+    <com.google.android.material.textview.MaterialTextView
+      android:id="@+id/restrictionTV"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="10dp"
+      android:textSize="15sp"
+      app:layout_constraintTop_toBottomOf="@id/statusTV"
+      android:text="@string/app_restrictions"
+      android:visibility="gone"
+      tools:visibility="visible" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -66,6 +66,8 @@
     <string name="code_signature_not_found">Nous n\'avons pas trouvé la signature de pisteurs que nous connaissons dans cette application.</string>
     <string name="tracker_info">Un pisteur est une partie du logiciel dédiée à la collecte de données sur vous et vos usages.</string>
     <string name="analyzed">Cette application n\'a pas encore été analysée par Exodus Privacy.</string>
+    <string name="app_restrictions">Exodus ne peut pas analyser des applications indisponibles sur Google Play ou FDroid ou liées à des restrictions géographiques ou logiciels.</string>
+
 
     <!-- ADPermissions Fragment -->
     <string name="code_permission_found">Nous avons trouvé les autorisations suivantes dans cette application :</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,6 +74,7 @@
     <string name="code_signature_not_found">We have not found code signature of any tracker we know in the application.</string>
     <string name="tracker_info">A tracker is a piece of software meant to collect data about you or your usages.</string>
     <string name="analyzed">This app hasn\'t been analysed by Exodus Privacy yet.</string>
+    <string name="app_restrictions">Exodus cannot analyze applications that are unavailable on Google Play or FDroid or are related to geographic or software restrictions.</string>
 
     <!-- ADPermissions Fragment -->
     <string name="code_permission_found">We have found the following permissions in the application:</string>


### PR DESCRIPTION
This PR adds a new text when an app doesn't have reports on exodus to explain the potential reasons why cannot be analyzed by exodus.

|Before|After|
|-|-|
|<img src="https://github.com/Exodus-Privacy/exodus-android-app/assets/87148630/c736b8eb-8d47-4ab5-ae3c-4addd1203030" height=500 />|<img src="https://github.com/Exodus-Privacy/exodus-android-app/assets/87148630/3cbccd90-af02-44ce-abea-5bd049d57997" height=500/>|