### PR TITLE
Add new Intent utils class

### DIFF
--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/about/AboutFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/about/AboutFragment.kt
@@ -1,8 +1,5 @@
 package org.eu.exodus_privacy.exodusprivacy.fragments.about
 
-import android.content.ActivityNotFoundException
-import android.content.Intent
-import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
@@ -18,6 +15,7 @@ import org.eu.exodus_privacy.exodusprivacy.databinding.FragmentAboutBinding
 import org.eu.exodus_privacy.exodusprivacy.fragments.dialog.ThemeDialogFragment
 import org.eu.exodus_privacy.exodusprivacy.utils.getLanguage
 import org.eu.exodus_privacy.exodusprivacy.utils.openURL
+import org.eu.exodus_privacy.exodusprivacy.utils.startIntent
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -60,15 +58,12 @@ class AboutFragment : PreferenceFragmentCompat() {
         toolbar.setOnMenuItemClickListener {
             when (it.itemId) {
                 R.id.chooseLanguage -> {
-                    val intent = Intent(Settings.ACTION_APP_LOCALE_SETTINGS).apply {
-                        data = Uri.parse("package:" + BuildConfig.APPLICATION_ID)
-                    }
-                    try {
-                        startActivity(intent)
-                        true
-                    } catch (e: ActivityNotFoundException) {
-                        false
-                    }
+                    startIntent(
+                        requireContext(),
+                        "system",
+                        Settings.ACTION_APP_LOCALE_SETTINGS,
+                        BuildConfig.APPLICATION_ID,
+                    )
                 }
 
                 R.id.chooseTheme -> {
@@ -109,13 +104,7 @@ class AboutFragment : PreferenceFragmentCompat() {
 
         // Open default email app for support
         findPreference<Preference>("email")?.setOnPreferenceClickListener {
-            val intent = Intent(Intent.ACTION_VIEW, Uri.parse("mailto:$emailID"))
-            try {
-                startActivity(intent)
-                true
-            } catch (e: ActivityNotFoundException) {
-                false
-            }
+            startIntent(requireContext(), "mail", emailID, null)
         }
 
         findPreference<Preference>("analyze")?.setOnPreferenceClickListener {

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/AppDetailFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/appdetail/AppDetailFragment.kt
@@ -1,7 +1,5 @@
 package org.eu.exodus_privacy.exodusprivacy.fragments.appdetail
 
-import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.provider.Settings
 import android.util.Log
@@ -20,6 +18,7 @@ import org.eu.exodus_privacy.exodusprivacy.R
 import org.eu.exodus_privacy.exodusprivacy.databinding.FragmentAppDetailBinding
 import org.eu.exodus_privacy.exodusprivacy.fragments.appdetail.model.AppDetailVPAdapter
 import org.eu.exodus_privacy.exodusprivacy.utils.openURL
+import org.eu.exodus_privacy.exodusprivacy.utils.startIntent
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -91,11 +90,12 @@ class AppDetailFragment : Fragment(R.layout.fragment_app_detail) {
                                 )
                             }
                             R.id.openAppInfo -> {
-                                val intent =
-                                    Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
-                                        data = Uri.parse("package:" + app.packageName)
-                                    }
-                                startActivity(intent)
+                                startIntent(
+                                    requireContext(),
+                                    "system",
+                                    Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                                    app.packageName,
+                                )
                             }
                             else -> {
                                 Log.d(TAG, "Unexpected itemId: ${it.itemId}")

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/IntentUtils.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/IntentUtils.kt
@@ -8,10 +8,18 @@ import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsIntent
 import java.util.Collections
 
-fun startActivity(context: Context, url: String) {
-    try {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+fun startIntent(context: Context, type: String, value: String, app: String?): Boolean {
+    var intent = Intent()
+    when (type) {
+        "web" -> intent = Intent(Intent.ACTION_VIEW, Uri.parse(value))
+        "system" -> intent = Intent(value).apply {
+            data = Uri.parse("package:$app")
+        }
+        "mail" -> intent = Intent(Intent.ACTION_VIEW, Uri.parse("mailto:$value"))
+    }
+    return try {
         context.startActivity(intent)
+        true
     } catch (e: ActivityNotFoundException) {
         false
     }
@@ -25,6 +33,6 @@ fun openURL(customTabsIntent: CustomTabsIntent, context: Context, url: String) {
     if (packageName != null) {
         customTabsIntent.launchUrl(context, Uri.parse(url))
     } else {
-        startActivity(context, url)
+        startIntent(context, "web", url, null)
     }
 }


### PR DESCRIPTION
This PR:
- Rename `BrowserUtils` to `IntentUtils` class
- Remove `startWebActivity` function
- Add `startIntent` function to open Intent (URL, Intent to settings, mail adress)
- Replaces `startActivity` with `startIntent`  in all classes