### PR TITLE
Remove support of Android 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ https://crowdin.com/project/exodus-android-app
 **If you would like to improve app code and have development skills, you are most welcome.**
 - You can find work in [issues](https://github.com/Exodus-Privacy/exodus-android-app/issues).
 - Before submitting pull requests please, execute Kotlin Liner and instrumented tests.
-- Change needs to work on all devices between Android 5 and Android 14.
+- Change needs to work on all devices between Android 6 and Android 14.
 - UI changes need to work in light mode, dark mode, and RTL.
 - Do not create pull requests to update dependencies, we have [dependabot](https://github.com/Exodus-Privacy/exodus-android-app/blob/master/.github/dependabot.yml).
 
@@ -88,6 +88,10 @@ https://crowdin.com/project/exodus-android-app
 
 - To execute tests move [network_security_config.xml](/doc/network_security_config.xml) to [/app/src/main/res/xml](/app/src/main/res/xml)
 - Add ```android:networkSecurityConfig="@xml/network_security_config"``` in [AndroidManifest.xml](/app/src/main/AndroidManifest.xml)
+
+### How to use app on Android 5
+
+- We have recently drop the support of Android 5, but 3.3.0 version continue to be available [here](https://github.com/Exodus-Privacy/exodus-android-app/releases/tag/release-v3.3.0)
 
 ### Links
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,10 +19,10 @@ android {
 
     defaultConfig {
         applicationId = "org.eu.exodus_privacy.exodusprivacy"
-        minSdk = 21
+        minSdk = 23
         targetSdk = 34
-        versionCode = 21
-        versionName = "3.3.0"
+        versionCode = 22
+        versionName = "3.3.1"
         testInstrumentationRunner = "org.eu.exodus_privacy.exodusprivacy.ExodusTestRunner"
         val API_KEY = System.getenv("EXODUS_API_KEY")
         buildConfigField("String", "EXODUS_API_KEY", "\"$API_KEY\"")

--- a/fastlane/metadata/android/en-US/changelogs/22.txt
+++ b/fastlane/metadata/android/en-US/changelogs/22.txt
@@ -1,0 +1,1 @@
+- Drop support of Android 5

--- a/fastlane/metadata/android/fr-FR/changelogs/22.txt
+++ b/fastlane/metadata/android/fr-FR/changelogs/22.txt
@@ -1,0 +1,1 @@
+- Suppression du support d'Android 5


### PR DESCRIPTION
Fixes #435

This PR:
- Remove support of Android 5 and Android 5.1
- Bump app version
- Add changelogs
- Update readme to explain to the user that old versions continue to work on Android 5

[Build test release](https://github.com/Exodus-Privacy/exodus-android-app/actions/runs/9145419659)

With this new version, we save 0,1Mb