### PR TITLE
Fix name app in About Fragment

### DIFF
--- a/app/src/main/res/layout-land/fragment_about.xml
+++ b/app/src/main/res/layout-land/fragment_about.xml
@@ -31,7 +31,7 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/appNameTV"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:layout_constraintStart_toStartOf="@id/imageView"
         app:layout_constraintEnd_toEndOf="@id/imageView"

--- a/app/src/main/res/layout-sw600dp-land/fragment_about.xml
+++ b/app/src/main/res/layout-sw600dp-land/fragment_about.xml
@@ -30,7 +30,7 @@
       app:layout_constraintVertical_bias="0.5" />
     <com.google.android.material.textview.MaterialTextView
       android:id="@+id/appNameTV"
-      android:layout_width="0dp"
+      android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:text="@string/app_name"
       android:textAlignment="center"


### PR DESCRIPTION
When the user uses a big police name of the app is cut on About screen.

|Before|After|
|-|-|
|<img src="https://github.com/Exodus-Privacy/exodus-android-app/assets/87148630/e4fec48f-cae5-4fba-b899-00d1ffb7b4fb" height=150 />|<img src="https://github.com/Exodus-Privacy/exodus-android-app/assets/87148630/0747fee1-b505-4517-bad4-01072741ca2e" height=150 />|
