### PR TITLE
Fix warning

### DIFF
--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/IntentUtils.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/IntentUtils.kt
@@ -9,7 +9,7 @@ import androidx.browser.customtabs.CustomTabsIntent
 import java.util.Collections
 
 fun startIntent(context: Context, type: String, value: String, app: String?): Boolean {
-    var intent = Intent()
+    lateinit var intent: Intent
     when (type) {
         "web" -> intent = Intent(Intent.ACTION_VIEW, Uri.parse(value))
         "system" -> intent = Intent(value).apply {


### PR DESCRIPTION
This PR fixes Android Studio warning because we init a variable with a null intent. I have replace null init with lateinit to tell to the compiler that variable is init later and adds the type of variable.