### PR TITLE
Add new screen utils class

### DIFF
--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/apps/AppsFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/apps/AppsFragment.kt
@@ -2,7 +2,6 @@ package org.eu.exodus_privacy.exodusprivacy.fragments.apps
 
 import android.content.Context
 import android.content.Intent
-import android.content.res.Configuration
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -23,6 +22,7 @@ import org.eu.exodus_privacy.exodusprivacy.ExodusUpdateService
 import org.eu.exodus_privacy.exodusprivacy.R
 import org.eu.exodus_privacy.exodusprivacy.databinding.FragmentAppsBinding
 import org.eu.exodus_privacy.exodusprivacy.fragments.apps.model.AppsRVAdapter
+import org.eu.exodus_privacy.exodusprivacy.utils.getColumnScreen
 
 @AndroidEntryPoint
 class AppsFragment : Fragment(R.layout.fragment_apps), Toolbar.OnMenuItemClickListener {
@@ -109,13 +109,7 @@ class AppsFragment : Fragment(R.layout.fragment_apps), Toolbar.OnMenuItemClickLi
         val appsRVAdapter = AppsRVAdapter(findNavController().currentDestination!!.id)
         binding.appListRV.apply {
             adapter = appsRVAdapter
-            val column: Int =
-                if (resources.configuration.smallestScreenWidthDp >= 600 && resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-                    2
-                } else {
-                    1
-                }
-            layoutManager = StaggeredGridLayoutManager(column, 1)
+            layoutManager = StaggeredGridLayoutManager(getColumnScreen(context), 1)
             addOnScrollListener(
                 object : RecyclerView.OnScrollListener() {
                     override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/trackerdetail/TrackerDetailFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/trackerdetail/TrackerDetailFragment.kt
@@ -1,6 +1,5 @@
 package org.eu.exodus_privacy.exodusprivacy.fragments.trackerdetail
 
-import android.content.res.Configuration
 import android.os.Bundle
 import android.text.method.LinkMovementMethod
 import android.text.util.Linkify
@@ -21,6 +20,7 @@ import org.eu.exodus_privacy.exodusprivacy.R
 import org.eu.exodus_privacy.exodusprivacy.databinding.FragmentTrackerDetailBinding
 import org.eu.exodus_privacy.exodusprivacy.fragments.apps.model.AppsRVAdapter
 import org.eu.exodus_privacy.exodusprivacy.utils.copyToClipboard
+import org.eu.exodus_privacy.exodusprivacy.utils.getColumnScreen
 import org.eu.exodus_privacy.exodusprivacy.utils.openURL
 import java.util.regex.Pattern
 import javax.inject.Inject
@@ -139,13 +139,7 @@ class TrackerDetailFragment : Fragment(R.layout.fragment_tracker_detail) {
                 binding.appsListRV.apply {
                     visibility = View.VISIBLE
                     adapter = appsRVAdapter
-                    val column: Int =
-                        if (resources.configuration.smallestScreenWidthDp >= 600 && resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-                            2
-                        } else {
-                            1
-                        }
-                    layoutManager = StaggeredGridLayoutManager(column, 1)
+                    layoutManager = StaggeredGridLayoutManager(getColumnScreen(context), 1)
                 }
                 appsRVAdapter.submitList(it)
             }

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/trackers/TrackersFragment.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/fragments/trackers/TrackersFragment.kt
@@ -1,7 +1,6 @@
 package org.eu.exodus_privacy.exodusprivacy.fragments.trackers
 
 import android.content.Intent
-import android.content.res.Configuration
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -15,6 +14,7 @@ import org.eu.exodus_privacy.exodusprivacy.ExodusUpdateService
 import org.eu.exodus_privacy.exodusprivacy.R
 import org.eu.exodus_privacy.exodusprivacy.databinding.FragmentTrackersBinding
 import org.eu.exodus_privacy.exodusprivacy.fragments.trackers.model.TrackersRVAdapter
+import org.eu.exodus_privacy.exodusprivacy.utils.getColumnScreen
 
 @AndroidEntryPoint
 class TrackersFragment : Fragment(R.layout.fragment_trackers) {
@@ -34,13 +34,7 @@ class TrackersFragment : Fragment(R.layout.fragment_trackers) {
             TrackersRVAdapter(false, findNavController().currentDestination!!.id)
         binding.trackersListRV.apply {
             adapter = trackersRVAdapter
-            val column: Int =
-                if (resources.configuration.smallestScreenWidthDp >= 600 && resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-                    2
-                } else {
-                    1
-                }
-            layoutManager = GridLayoutManager(context, column)
+            layoutManager = GridLayoutManager(context, getColumnScreen(context))
         }
 
         // Setup Shimmer Layout

--- a/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/ScreenUtils.kt
+++ b/app/src/main/java/org/eu/exodus_privacy/exodusprivacy/utils/ScreenUtils.kt
@@ -1,0 +1,8 @@
+package org.eu.exodus_privacy.exodusprivacy.utils
+
+import android.content.Context
+import android.content.res.Configuration
+
+fun getColumnScreen(context: Context): Int {
+    return if (context.resources.configuration.smallestScreenWidthDp >= 600 && context.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) 2 else 1
+}


### PR DESCRIPTION
This PR:
- Create a new Screen util class
- Create a new function `getColumnScreen` to get the size of the screen and return the number of columns used in UI (used on tablet to have two columns and use all space of screen)
- Use new function in all classes