### PR TITLE
set allowBackup to true

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
 
     <application
         android:name=".ExodusApplication"
-        android:allowBackup="false"
+        android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:enableOnBackInvokedCallback="true"
         android:fullBackupContent="false"


### PR DESCRIPTION
allow users to backup the app's internal files and databases

Why?
more freedom of decision, control and tinkering to the end-user
