### PR TITLE
set supportsRtl to false

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
         android:label="@string/app_name"
         android:largeHeap="true"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
+        android:supportsRtl="false"
         android:theme="@style/Theme.Exodus.Splash"
         tools:ignore="GoogleAppIndexingWarning">
         <activity


### PR DESCRIPTION
Since the app doesn't currently provide RTL languages translations and the default and only available language is English (which only needs an LTR layout) and since running the app on an RTL enabled language OS causes layout items not to appear correctly and unnecessarily aligned to the right which is counter intuitive and annoying.

An example of RTL english and some layout issues:
![s](https://github.com/user-attachments/assets/21492704-d792-46d3-8033-31cc8db1b90f)

